### PR TITLE
remote template.json line in default settings file

### DIFF
--- a/packages/athena/json_docs/default_settings_doc.json
+++ b/packages/athena/json_docs/default_settings_doc.json
@@ -32,8 +32,7 @@
 		"DB_COMPONENTS": {
 			"description": "db for peers/cas/orderers/collections/msps docs",
 			"design_docs": [
-				"../json_docs/components_design_doc.json",
-				"../json_docs/template.json"
+				"../json_docs/components_design_doc.json"
 			],
 			"name": "athena_components"
 		},


### PR DESCRIPTION
fixes error:
```
08:57:09 - error: [db startup] unable to read json file. cannot add to database. ../json_docs/template.json message=Cannot find module '../json_docs/template.json'
```

Signed-off-by: David Huffman <dshuffma@us.ibm.com>