### PR TITLE
Fix channel not found error

### DIFF
--- a/packages/apollo/src/rest/ChannelApi.js
+++ b/packages/apollo/src/rest/ChannelApi.js
@@ -555,10 +555,10 @@ class ChannelApi {
 	}
 	static getOrdererAddresses(config) {
 		let addresses = [];
-		const orderer_grp = _.get(config, 'channel_group.groups_map.Orderer.groups_map');
 		const l_orderers = _.get(config, 'channel_group.values_map.OrdererAddresses.value.addresses_list');
 		addresses.push(...l_orderers);
 		if (addresses.length === 0) {
+			const orderer_grp = _.get(config, 'channel_group.groups_map.Orderer.groups_map');
 			for (let ordererMSP in orderer_grp) {
 				addresses.push(...orderer_grp[ordererMSP].values_map.Endpoints.value.addresses);
 			}


### PR DESCRIPTION
Error when getting channel Details because of `.values_map.Endpoints` being null. I have just changed the if condition. Let me know if this is acceptable.
I am getting Null for Endpoint, but the `channel_group.values_map.OrdererAddresses.value.addresses_list` is successful