### PR TITLE
fix max component limit, only count peers/cas/os

### DIFF
--- a/packages/athena/libs/component_lib.js
+++ b/packages/athena/libs/component_lib.js
@@ -291,10 +291,11 @@ module.exports = function (logger, ev, t) {
 		});
 	};
 
-	// count the optool ids
+	// count the optools ids - only count component ids (peer, ca, orderers)
 	function count_ids(obj) {
 		if (obj && Array.isArray(obj.doc_ids)) {
-			return obj.doc_ids.length;
+			const no_sig_collections = obj.doc_ids.filter(id => (id.indexOf('sc_') !== 0 && id.indexOf('00_') !== 0));
+			return no_sig_collections.length;
 		}
 		return 0;
 	}


### PR DESCRIPTION
The max component limit is counting signature collection docs, which wasn't intended. The max component limit should only limit the number of peers/cas/orderers based on the number of peers/cas/orderers.

Signed-off-by: David Huffman <dshuffma@us.ibm.com>