### PR TITLE
create setting to allow users to keep default pass

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -15,6 +15,9 @@
 1. What APIs does the console offer?
 	- See our [API page](./docs/apis.md) for details.
 
+1. Can I skip the password change after first login?
+	- Normally users are forced to change their password after the first login. If you are creating a developer setup often this can be a hassle. If you would like to disable this behavior, set the field `allow_default_password` as `true` in your [config.yaml](https://github.com/hyperledger-labs/fabric-operations-console/blob/main/docker/console/env/config.yaml).
+
 ## Error Help:
 
 - Crypto.subtle errors look like:

--- a/packages/athena/env/README.md
+++ b/packages/athena/env/README.md
@@ -232,6 +232,11 @@ __default_settings_doc.json:__
 // email address on the UI to surface to users for help
 "admin_contact_email": "ibm@us.ibm.com",
 
+// if true users are allowed to keep the default password.
+// if false users will be forced to set a new password after their first login.
+// defaults false
+"allow_default_password": false
+
 // legacy! - ignore me
 // app id settings go here, leave it as is if using ibm id
 // (not used if auth_scheme is not "appid")

--- a/packages/athena/json_docs/default_settings_doc.json
+++ b/packages/athena/json_docs/default_settings_doc.json
@@ -15,6 +15,7 @@
 	},
 	"integration_test_enabled": false,
 	"app_port": 3000,
+	"allow_default_password": false,
 	"auth_scheme": "initial",
 	"backend_address_timeout_ms": 3000,
 	"ca_proxy_timeout": 10000,

--- a/packages/athena/libs/authentication_lib.js
+++ b/packages/athena/libs/authentication_lib.js
@@ -123,7 +123,7 @@ module.exports = function (logger, ev, t) {
 			req.session.couchdb_profile = {									// init the session data
 				name: make_name(lc_email),
 				email: lc_email,
-				password_type: 'custom',									// tells us if the login was done using a default password or not
+				password_type: ev.STR.PASS_IS_CUSTOM,						// tells us if the login was done using a default password or not
 			};
 			req.session.couchdb_profile.uuid = t.middleware.getUuid(req);	// must call this after init of couchdb_profile
 
@@ -152,7 +152,7 @@ module.exports = function (logger, ev, t) {
 				let known_hashed_secret = ev.ACCESS_LIST[lc_email].hashed_secret;
 				if (!known_hashed_secret && ev.DEFAULT_USER_PASSWORD) {		// if DEFAULT_USER_PASSWORD is null, don't do use this fallback
 					logger.warn('[auth] no password set for user', t.misc.censorEmail(lc_email), '. will use default password');
-					req.session.couchdb_profile.password_type = 'default';
+					req.session.couchdb_profile.password_type = (ev.ALLOW_DEFAULT_PASSWORD === true) ? ev.STR.PASS_IS_CUSTOM : ev.STR.PASS_IS_DEFAULT;
 					const secret_details = t.misc.salt_secret(ev.DEFAULT_USER_PASSWORD);
 					salt = secret_details.salt;
 					known_hashed_secret = secret_details.hashed_secret;

--- a/packages/athena/libs/middleware/middleware.js
+++ b/packages/athena/libs/middleware/middleware.js
@@ -361,7 +361,8 @@ module.exports = function (logger, ev, t) {
 
 				// if we are a Software OpTools AND the request is for creating an API key -> let it work if request's password matches the default password
 				if (ev.AUTH_SCHEME !== 'iam' && req.method === 'POST' &&
-					(req.path.includes('/permissions/keys') || req.path.includes('/identity/token'))) {
+					(req.path.includes('/permissions/keys') || req.path.includes('/identity/token'))
+					|| (ev.AUTH_SCHEME !== 'iam' && ev.ALLOW_DEFAULT_PASSWORD)) {
 					logger.warn('[middle] no password set for user. checking against default password:', t.misc.censorEmail(username));
 					const secret_details = t.misc.salt_secret(ev.DEFAULT_USER_PASSWORD);
 					salt = secret_details.salt;

--- a/packages/athena/libs/settings.js
+++ b/packages/athena/libs/settings.js
@@ -222,6 +222,7 @@ module.exports = function (logger, t, noInterval, noAutoRun) {
 				settings.ACTIVITY_TRACKER_PATH = athena.activity_tracker_path;
 				settings.MAX_COMPONENTS = !isNaN(athena.max_components) ? Number(athena.max_components) : 250;
 				settings.IMPORT_ONLY = athena.feature_flags ? athena.feature_flags.import_only_enabled : false;
+				settings.ALLOW_DEFAULT_PASSWORD = athena.allow_default_password ? true : false;
 
 				// allow integration test to be ran from the provided UI
 				settings.integration_test_enabled = athena.integration_test_enabled ? athena.integration_test_enabled : false;
@@ -351,6 +352,8 @@ module.exports = function (logger, t, noInterval, noAutoRun) {
 					IBP_TOKEN: 'ibp',
 					IAM_TOKEN: 'iam',
 					FAB_UP_LOCK_NAME: 'auto_fabric_upgrade',
+					PASS_IS_CUSTOM: 'custom',
+					PASS_IS_DEFAULT: 'default',
 				};
 
 				// manager - must match what is defined in RMC (this section ONLY applies to stand alone)


### PR DESCRIPTION
added the setting `allow_default_password`
- if `true` users are allowed to keep the default password
- if `false` users will be forced to set a new password after their first login
- defaults `false`

https://github.com/hyperledger-labs/fabric-operations-console/issues/79