### PR TITLE
Fix auto fabric upgrade parsing

### DIFF
--- a/packages/athena/libs/deployer_lib.js
+++ b/packages/athena/libs/deployer_lib.js
@@ -2020,12 +2020,14 @@ module.exports = function (logger, ev, t) {
 			};
 			logger.debug('[deployer lib]', parsed.debug_tx_id, ' sending deployer api w/route:', opts.url);
 			/*return lc_cb(null, {
-				orderer: {
-					'2.2.99': {
-						default: true
-					},
-					'1.4.999': {
-						default: true
+				versions: {
+					orderer: {
+						'2.2.99': {
+							default: true
+						},
+						'1.4.999': {
+							default: true
+						}
 					}
 				}
 			});*/

--- a/packages/athena/libs/patch_lib.js
+++ b/packages/athena/libs/patch_lib.js
@@ -415,6 +415,7 @@ module.exports = function (logger, ev, t) {
 					// already logged, skip this component & continue
 					return async_cb();
 				}
+				logger.debug('[fab upgrade] looking at component:', comp_doc._id, 'with version:', comp_doc.version);
 
 				should_upgrade(upgrade_to_version, comp_doc, (_, should_do_upgrade) => {
 					if (!should_do_upgrade) {
@@ -433,6 +434,7 @@ module.exports = function (logger, ev, t) {
 								version: upgrade_to_version				// this is the version we will upgrade to
 							}
 						};
+						logger.debug('[fab upgrade] sending body for fab upgrade:', JSON.stringify(fake_req.body));
 						t.deployer.update_component(fake_req, (err_resp, resp) => {
 							if (err_resp) {
 								logger.error('[fab upgrade] failed to upgrade component. dep error.', comp_doc._id, err_resp);

--- a/packages/athena/libs/patch_lib.js
+++ b/packages/athena/libs/patch_lib.js
@@ -308,17 +308,25 @@ module.exports = function (logger, ev, t) {
 	// Patch 2 - 03/20/2020
 	// this patch upgrades orderer that are older than < 1.4.9 or < 2.2.1
 	// (the upgrade will NOT upgrade past major version changes)
+	/*
+	opts: {
+		"manual": true || false					// if its manual, we ignore the DISABLE_AUTO_FAB_UP setting
+	}
+	*/
 	// ----------------------------------------------------------------------------------
-	patch.auto_upgrade_orderers = (cb) => {
+	patch.auto_upgrade_orderers = (opts, cb) => {
 		if (!cb) {
 			cb = function () { };
 		}
+		if (!opts) {
+			opts = {};
+		}
 		let wait_interval = null;
 
-		if (ev.DISABLE_AUTO_FAB_UP) {
+		if (ev.DISABLE_AUTO_FAB_UP && !opts.manual) {
 			logger.debug('[fab upgrade] auto fabric upgrade is disabled via setting. skipping.');
 		} else {
-			logger.debug('[fab upgrade] starting auto fabric upgrade check. looking for comps lower than:', ev.AUTO_FAB_UP_VERSIONS);
+			logger.debug('[fab upgrade] starting fabric upgrade check. looking for comps lower than:', ev.AUTO_FAB_UP_VERSIONS);
 
 			// get a lock if we can, prevents multiple athena instances from doing the same logic
 			t.lock_lib.apply({ lock: ev.STR.FAB_UP_LOCK_NAME, max_locked_sec: 5 * 60 }, (lock_err) => {
@@ -334,7 +342,7 @@ module.exports = function (logger, ev, t) {
 						logger.debug('[fab upgrade] orderer versions available:', orderer_keys);
 
 						if (orderer_keys.length === 0) {
-							logger.error('[fab upgrade] unable to find available orderer versions for auto upgrade.', orderer_keys);
+							logger.error('[fab upgrade] unable to find available orderer versions for fab upgrade.', orderer_keys);
 							t.lock_lib.release(ev.STR.FAB_UP_LOCK_NAME);
 							return cb();
 						} else {
@@ -360,7 +368,7 @@ module.exports = function (logger, ev, t) {
 				_skip_cache: true,
 			};
 			t.deployer.get_fabric_versions(fake_req, (err, resp) => {
-				return dep_cb(err, resp);
+				return dep_cb(err, resp ? resp.versions : null);
 			});
 		}
 

--- a/packages/athena/routes/other_apis.js
+++ b/packages/athena/routes/other_apis.js
@@ -471,7 +471,7 @@ module.exports = function (logger, ev, t) {
 
 	// start a fabric upgrade check
 	function run_upgrade_check(res, req) {
-		t.patch_lib.auto_upgrade_orderers();
+		t.patch_lib.auto_upgrade_orderers({ manual: true });
 		return res.status(200).json({ message: 'ok', details: 'started' });
 	}
 


### PR DESCRIPTION
The auto fabric upgrade logic was not parsing the get-available-fabric-versions api response correctly, causes the upgrade api to fail.

This PR also now ignores the db setting `DISABLE_AUTO_FAB_UP` when calling the fabric upgrade manually. meaning the setting `DISABLE_AUTO_FAB_UP` only applies to the automatic fabric upgrade logic.