### PR TITLE
Auto upgrade version fix

### DIFF
--- a/packages/athena/json_docs/default_settings_doc.json
+++ b/packages/athena/json_docs/default_settings_doc.json
@@ -1,8 +1,8 @@
 {
 	"_id": "00_settings_athena",
 	"auto_fab_up_versions": [
-		"1.4.9",
-		"2.2.1"
+		"1.4.9-3",
+		"2.2.1-3"
 	],
 	"auto_fab_up_exp_too_close_days": 5,
 	"access_list": {},

--- a/packages/athena/json_docs/default_settings_doc.json
+++ b/packages/athena/json_docs/default_settings_doc.json
@@ -1,8 +1,8 @@
 {
 	"_id": "00_settings_athena",
 	"auto_fab_up_versions": [
-		"1.4.9-3",
-		"2.2.1-3"
+		"1.4.9-1",
+		"2.2.1-1"
 	],
 	"auto_fab_up_exp_too_close_days": 5,
 	"access_list": {},

--- a/packages/athena/libs/misc.js
+++ b/packages/athena/libs/misc.js
@@ -1255,6 +1255,10 @@ module.exports = function (logger, t) {
 			return null;
 		}
 
+		// make them the same length, defaults to 0
+		for (; version_parts_a.length < version_parts_b.length;) { version_parts_a.push('0'); }
+		for (; version_parts_b.length < version_parts_a.length;) { version_parts_b.push('0'); }
+
 		for (let i in version_parts_a) {
 			if (version_parts_b[i] > version_parts_a[i]) {
 				return true;

--- a/packages/athena/libs/patch_lib.js
+++ b/packages/athena/libs/patch_lib.js
@@ -464,13 +464,13 @@ module.exports = function (logger, ev, t) {
 		}
 
 		// find the highest version we can use to upgrade this orderer.
-		// do not move up major or minor versions, only patch, and pre-releases.
+		// do not move up major versions, only minor, patch and pre-releases.
 		function highest_version_available(available_versions, at_version) {
 			const at_major_ver = get_major(at_version);
-			const at_minor_ver = get_minor(at_version);
+			//const at_minor_ver = get_minor(at_version);
 			const possible_arr = [];							// should hold the versions at the same major & minor versions
 			for (let i in available_versions) {
-				if (get_major(available_versions[i]) === at_major_ver && get_minor(available_versions[i]) === at_minor_ver) {
+				if (get_major(available_versions[i]) === at_major_ver/* && get_minor(available_versions[i]) === at_minor_ver*/) {
 					possible_arr.push(available_versions[i]);
 				}
 			}
@@ -488,10 +488,10 @@ module.exports = function (logger, ev, t) {
 			}
 
 			// get the second number off the version, the major digits
-			function get_minor(version) {
+			/*function get_minor(version) {
 				const parts = (version && typeof version === 'string') ? version.split('.') : [];
 				return parts.length > 1 ? parts[1] : null;
-			}
+			}*/
 		}
 
 		// based on the component doc version && cert expirations, should we upgrade this component

--- a/packages/athena/test/test-suites/lib/misc.test.js
+++ b/packages/athena/test/test-suites/lib/misc.test.js
@@ -11,6 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
+/* eslint-disable max-len */
 //------------------------------------------------------------
 // misc_test.js - test for the misc lib
 //------------------------------------------------------------
@@ -19,7 +20,6 @@ const chai = require('chai');
 const expect = chai.expect;
 const tools = common.tools;
 const misc = require('../../../libs/misc.js')(common.logger, tools);
-const component_properties = require('../../docs/component_properties.json');
 const filename = tools.path.basename(__filename);
 const path_to_current_file = tools.path.join(__dirname + '/' + filename);
 const misc_objects = require('../../docs/misc_objects.json');
@@ -2008,7 +2008,8 @@ describe('Misc', () => {
 						{
 							itStatement: 'should leave jwt alone - test_id=hgvhqi',
 							expectBlock: (done) => {
-								const jwt = 'eyJraWQiOiIyMDIwMDkyMjE4MzMiLCJhbGciOiJSUzI1NiJ9.eyJpYW1faWQiOiJJQk1pZC0yp00iiXX0.P5ale38vMl0ufyZ2iEZZkp-J-jFvLf_jAz2D2_JoUJujDBc38-oRjF7F5UA_BAVUHeExRp-8i8Pb_6TbjFQ_mPBytRj6yO-FZ57';
+								const jwt = 'eyJraWQiOiIyMDIwMDkyMjE4MzMiLCJhbGciOiJSUzI1NiJ9.eyJpYW1faWQiOiJJQk1pZC0yp00iiXX0.' +
+									'P5ale38vMl0ufyZ2iEZZkp-J-jFvLf_jAz2D2_JoUJujDBc38-oRjF7F5UA_BAVUHeExRp-8i8Pb_6TbjFQ_mPBytRj6yO-FZ57';
 								expect(misc.safe_jwt_str(jwt)).to.equal(jwt);
 
 								const jwt2 = 'abcd+/==.something.dahs-dot0123456789_';

--- a/packages/athena/test/test-suites/lib/misc.test.js
+++ b/packages/athena/test/test-suites/lib/misc.test.js
@@ -1832,6 +1832,19 @@ describe('Misc', () => {
 								done();
 							}
 						},
+
+						{
+							itStatement: 'should show that lower versions are lower with dashes and non dashes test_id=ledwid',
+							expectBlock: (done) => {
+								expect(misc.is_version_b_greater_than_a('1.4.9', '1.4.9-1')).to.equal(true);
+								expect(misc.is_version_b_greater_than_a('1.4.9', '1.4.9-0')).to.equal(false);
+								expect(misc.is_version_b_greater_than_a('1.4.9', '2.4.9-1')).to.equal(true);
+								expect(misc.is_version_b_greater_than_a('1.4.9', '2.4.9-0')).to.equal(true);
+								expect(misc.is_version_b_greater_than_a('1.4.9-1', '1.4.9')).to.equal(false);
+								expect(misc.is_version_b_greater_than_a('1.4.9-0', '1.4.9')).to.equal(false);
+								done();
+							}
+						},
 					]
 				}
 			]


### PR DESCRIPTION
- Bug fix

#### Description
- the auto upgrade fabric logic was upgrading from versions that were okay. it was upgrading all orderers to the highest available major fabric version, unless they were already at the highest level (within the same major version).

