### PR TITLE
fix version compare logic with double digit str

### DIFF
--- a/packages/athena/libs/misc.js
+++ b/packages/athena/libs/misc.js
@@ -1260,7 +1260,7 @@ module.exports = function (logger, t) {
 		for (; version_parts_b.length < version_parts_a.length;) { version_parts_b.push('0'); }
 
 		for (let i in version_parts_a) {
-			if (version_parts_b[i] > version_parts_a[i]) {
+			if (Number(version_parts_b[i]) > Number(version_parts_a[i])) {
 				return true;
 			} else if (version_parts_b[i] === version_parts_a[i]) {
 				// equal numbers at this level... keep going

--- a/packages/athena/test/test-suites/lib/misc.test.js
+++ b/packages/athena/test/test-suites/lib/misc.test.js
@@ -1845,6 +1845,20 @@ describe('Misc', () => {
 								done();
 							}
 						},
+
+						{
+							itStatement: 'should show that lower versions are lower with double digits test_id=qqhlve',
+							expectBlock: (done) => {
+								expect(misc.is_version_b_greater_than_a('1.4.9', '1.4.12')).to.equal(true);
+								expect(misc.is_version_b_greater_than_a('1.4.9', '1.4.10')).to.equal(true);
+								expect(misc.is_version_b_greater_than_a('1.4.9', '1.4.01')).to.equal(false);
+
+								expect(misc.is_version_b_greater_than_a('1.4.80', '1.4.9')).to.equal(false);
+								expect(misc.is_version_b_greater_than_a('1.4.90', '1.4.8')).to.equal(false);
+								expect(misc.is_version_b_greater_than_a('1.4.90', '1.4.01')).to.equal(false);
+								done();
+							}
+						},
 					]
 				}
 			]


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description
The version comparison logic did not work correctly when comparing 1 double digit version to a single digit version.

