### PR TITLE
fix refresh cert button, only show for deploy node

### DIFF
--- a/packages/apollo/src/components/OrdererDetails/OrdererDetails.js
+++ b/packages/apollo/src/components/OrdererDetails/OrdererDetails.js
@@ -1280,7 +1280,7 @@ class OrdererDetails extends Component {
 											noIdentityAssociation={!!this.props.selectedNode}
 											hideDelete={this.props.selectedNode ? !canDelete : false}
 											refreshCerts={this.refreshCerts}
-											hideRefreshCerts={!this.props.selectedNode || (this.props.details && this.props.details.location !== 'ibm_saas')}
+											hideRefreshCerts={!this.props.selectedNode || (this.props.selectedNode && this.props.selectedNode.location !== 'ibm_saas')}
 										/>
 									</FocusComponent>
 								</div>
@@ -1385,7 +1385,7 @@ class OrdererDetails extends Component {
 																			text: 'add_orderer_node',
 																			fn: this.openAddOrdererNode,
 																		},
-																	  ]
+																	]
 																	: []
 															}
 														/>
@@ -1397,8 +1397,8 @@ class OrdererDetails extends Component {
 													id="ibp-orderer-usage"
 													className={
 														this.props.selectedNode.isUpgradeAvailable &&
-														this.props.selectedNode.location === 'ibm_saas' &&
-														ActionsHelper.canCreateComponent(this.props.userInfo)
+															this.props.selectedNode.location === 'ibm_saas' &&
+															ActionsHelper.canCreateComponent(this.props.userInfo)
 															? 'ibp-patch-available-tab'
 															: ''
 													}


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

- Bug fix

#### Description
The "refresh cert" button should show up for deployed nodes and not show for imported nodes. This was not working as intended for orderering nodes. If the first orderer in an OS (when sorted by name alphabetically) was a deployed node, the console would show the button on all ordering nodes in that OS.

