### PR TITLE
allow associating identities from intermediate ca

### DIFF
--- a/packages/apollo/src/assets/i18n/en/messages.json
+++ b/packages/apollo/src/assets/i18n/en/messages.json
@@ -2015,7 +2015,7 @@
 	"join_peer_imp_link": "${DOC_PREFIX}ibp-console-adv-deployment#ibp-console-adv-deployment-level-couch",
 	"_JOIN_CHANNEL_LINK": "${DOC_PREFIX}ibp-console-build-network#ibp-console-build-network-join-peer",
 	"replica_sets_desc": "Replica sets guarantee the availability of the CA by ensuring that multiple replicas of the CA are running.",
-	"no_identities": "There are no identities in the wallet.",
+	"no_identities": "There are no applicable identities in the wallet.",
 	"no_ca_identities": "Please import your CA admin identity into your Wallet on the Wallet page.",
 	"no_peer_identities": "Please import your peer admin identity into your Wallet on the Wallet page.",
 	"no_orderer_identities": "Please import your Ordering service admin identity into your Wallet on the Wallet page.",

--- a/packages/apollo/src/components/OrdererModal/OrdererModal.js
+++ b/packages/apollo/src/components/OrdererModal/OrdererModal.js
@@ -293,15 +293,17 @@ class OrdererModal extends React.Component {
 		let valid_identities = {};
 		const allOrderers = this.props.orderer.raft ? this.props.orderer.raft : this.props.orderer;
 		let msp_root_certs = {};
+		let msp_root_certs_intermediate = {};
 		for (let orderer of allOrderers) {
 			msp_root_certs[orderer.msp_id] = _.get(orderer, 'msp.ca.root_certs');
+			msp_root_certs_intermediate[orderer.msp_id] = _.get(orderer, 'msp.intermediate_ca.root_certs');
 		}
 		for (const msp_id of keys) {
 			let identity4msp = [];
 			for (let l_identity of this.identities) {
 				let opts = {
 					certificate_b64pem: l_identity.cert,
-					root_certs_b64pems: msp_root_certs[msp_id],
+					root_certs_b64pems: Helper.safer_concat(msp_root_certs[msp_id], msp_root_certs_intermediate[msp_id]),
 				};
 				let match = await StitchApi.isIdentityFromRootCert(opts);
 				if (match) {
@@ -1043,7 +1045,7 @@ class OrdererModal extends React.Component {
 										{this.props.orderer.display_name}
 									</CodeSnippet>
 								),
-							  })
+							})
 							: translate('remove_orderer_desc', {
 								name: (
 									<CodeSnippet
@@ -1055,7 +1057,7 @@ class OrdererModal extends React.Component {
 										{this.props.orderer.display_name}
 									</CodeSnippet>
 								),
-							  })}
+							})}
 					</p>
 				</div>
 				<div>
@@ -1616,7 +1618,7 @@ class OrdererModal extends React.Component {
 					placeholder: 'private_key_placeholder',
 					tooltipDirection: 'bottom',
 				},
-			  ]
+			]
 			: [
 				{
 					name: 'saas_ca',
@@ -1645,7 +1647,7 @@ class OrdererModal extends React.Component {
 					label: 'orderer_enroll_secret',
 					placeholder: 'peer_enroll_secret_placeholder',
 				},
-			  ];
+			];
 		const show_hsm = this.props.ordererModalType === 'enable_hsm' || this.props.ordererModalType === 'update_hsm';
 		let valid = this.props.third_party_ca ? this.props.third_party_ca_valid : this.props.saas_ca_valid;
 		if (show_hsm) {
@@ -1663,7 +1665,7 @@ class OrdererModal extends React.Component {
 								action_in_progress: null,
 								ordererModalType: this.props.action_in_progress,
 							});
-						  }
+						}
 						: null
 				}
 			>
@@ -1684,7 +1686,7 @@ class OrdererModal extends React.Component {
 										third_party_ca: !this.props.third_party_ca,
 									});
 								}}
-								onChange={() => {}}
+								onChange={() => { }}
 								aria-label={translate('third_party_ca')}
 								labelA={translate('no')}
 								labelB={translate('yes')}

--- a/packages/apollo/src/components/PeerModal/PeerModal.js
+++ b/packages/apollo/src/components/PeerModal/PeerModal.js
@@ -99,6 +99,9 @@ class PeerModal extends React.Component {
 	getIdentities() {
 		let root_certs = _.get(this.props, 'peer.msp.ca.root_certs');
 		let tls_root_certs = _.get(this.props, 'peer.msp.tlsca.root_certs');
+		let tls_root_certs_intermediate = _.get(this.props, 'peer.msp.intermediate_tlsca.root_certs');
+		let root_certs_intermediate = _.get(this.props, 'peer.msp.intermediate_ca.root_certs');
+
 		let matched_identities = [];
 		let matched_tls_identities = [];
 		IdentityApi.getIdentities()
@@ -107,7 +110,7 @@ class PeerModal extends React.Component {
 					for (let l_identity of identities) {
 						let opts = {
 							certificate_b64pem: l_identity.cert,
-							root_certs_b64pems: root_certs,
+							root_certs_b64pems: Helper.safer_concat(root_certs, root_certs_intermediate),
 						};
 						let match = await StitchApi.isIdentityFromRootCert(opts);
 						if (match) {
@@ -116,7 +119,7 @@ class PeerModal extends React.Component {
 
 						let tls_opts = {
 							certificate_b64pem: l_identity.cert,
-							root_certs_b64pems: tls_root_certs,
+							root_certs_b64pems: Helper.safer_concat(tls_root_certs, tls_root_certs_intermediate),
 						};
 						let tls_match = await StitchApi.isIdentityFromRootCert(tls_opts);
 						if (tls_match) {
@@ -610,7 +613,7 @@ class PeerModal extends React.Component {
 										{this.props.peer.display_name}
 									</CodeSnippet>
 								),
-							  })
+							})
 							: translate('remove_peer_desc', {
 								name: (
 									<CodeSnippet
@@ -622,7 +625,7 @@ class PeerModal extends React.Component {
 										{this.props.peer.display_name}
 									</CodeSnippet>
 								),
-							  })}
+							})}
 					</p>
 				</div>
 				<div>
@@ -845,7 +848,7 @@ class PeerModal extends React.Component {
 					placeholder: 'private_key_placeholder',
 					tooltipDirection: 'bottom',
 				},
-			  ]
+			]
 			: [
 				{
 					name: 'saas_ca',
@@ -874,7 +877,7 @@ class PeerModal extends React.Component {
 					label: 'peer_enroll_secret',
 					placeholder: 'peer_enroll_secret_placeholder',
 				},
-			  ];
+			];
 		const show_hsm = this.props.peerModalType === 'enable_hsm' || this.props.peerModalType === 'update_hsm';
 		let valid = this.props.third_party_ca ? this.props.third_party_ca_valid : this.props.saas_ca_valid;
 		if (show_hsm) {
@@ -892,7 +895,7 @@ class PeerModal extends React.Component {
 								action_in_progress: null,
 								peerModalType: this.props.action_in_progress,
 							});
-						  }
+						}
 						: null
 				}
 			>
@@ -913,7 +916,7 @@ class PeerModal extends React.Component {
 										third_party_ca: !this.props.third_party_ca,
 									});
 								}}
-								onChange={() => {}}
+								onChange={() => { }}
 								aria-label={translate('third_party_ca')}
 								labelA={translate('no')}
 								labelB={translate('yes')}

--- a/packages/apollo/src/utils/helper.js
+++ b/packages/apollo/src/utils/helper.js
@@ -1448,6 +1448,23 @@ const Helper = {
 		}
 		return false;
 	},
+
+	// concat two array fields together
+	safer_concat(array1, array2) {
+		if (typeof array1 === 'string') {
+			array1 = [array1];						// make array of 1 if its just a string
+		}
+		if (typeof array2 === 'string') {
+			array2 = [array2];						// make array of 1 if its just a string
+		}
+		if (!Array.isArray(array1)) {
+			array1 = [];							// init empty array if null/anything else
+		}
+		if (!Array.isArray(array2)) {
+			array2 = [];							// init empty array if null/anything else
+		}
+		return array1.concat(array2);
+	}
 };
 
 export default Helper;

--- a/packages/athena/docs/_holy_cert.md
+++ b/packages/athena/docs/_holy_cert.md
@@ -220,6 +220,9 @@ This page is a work in progress. Trying to get a better handle on what cert is w
 		"tls_cert": "",    // aka comp's TLS cert
 		"ecert": "",     // aka comp's ecert
 		"admin_certs": [""], // aka comp's admin certs
+
+		"intermediate_certs": [""] // aka intermediate CA root-cert
+		"tls_intermediate_certs": [""] // aka intermediate TLS-CA root-cert
 	}
 	```
 - Athena's **external** (response) structure as of v3:
@@ -239,7 +242,15 @@ This page is a work in progress. Trying to get a better handle on what cert is w
 				"tls_cert": "",    // aka comp's TLS cert
 				"ecert": "",     // aka comp's ecert [NOT available if this comp is a CA]
 				"admin_certs": [""], // aka comp's admin certs [NOT available if this comp is a CA]
-			}
+			},
+
+			// optional
+			"intermediate_ca":{
+				"root_certs": [""],  // aka intermediate CA root-cert
+			},
+			"intermediate_tlsca":{
+				"root_certs": [""],  // aka intermediate TLS-CA root-cert
+			},
 		}
 	}
 

--- a/packages/athena/libs/comp_formatting_lib.js
+++ b/packages/athena/libs/comp_formatting_lib.js
@@ -233,7 +233,13 @@ module.exports = function (logger, ev, t) {
 					tls_cert: doc.tls_cert,
 					ecert: doc.ecert,
 					admin_certs: doc.admin_certs,
-				}
+				},
+				intermediate_ca: {
+					root_certs: doc.intermediate_certs,
+				},
+				intermediate_tlsca: {
+					root_certs: doc.tls_intermediate_certs,
+				},
 			};
 
 			if (doc.tlsca_name) {						// move internal field to v3 location
@@ -250,6 +256,12 @@ module.exports = function (logger, ev, t) {
 			}
 			if (!doc.msp.tlsca.root_certs && !doc.msp.tlsca.name) {
 				delete doc.msp.tlsca;							// remove empty fields
+			}
+			if (!Array.isArray(doc.msp.intermediate_ca.root_certs) || doc.msp.intermediate_ca.root_certs.length === 0) {
+				delete doc.msp.intermediate_ca;					// remove empty fields
+			}
+			if (!Array.isArray(doc.msp.intermediate_tlsca.root_certs) || doc.msp.intermediate_tlsca.root_certs.length === 0) {
+				delete doc.msp.intermediate_tlsca;				// remove empty fields
 			}
 
 			if (t.component_lib.include_parsed_certs(req)) {
@@ -269,6 +281,8 @@ module.exports = function (logger, ev, t) {
 			delete doc.tls_ca_root_certs_parsed;
 			delete doc.admin_certs_parsed;
 			delete doc.tls_cert_parsed;
+			//delete doc.intermediate_certs;		// leave this field, too much code to change
+			//delete doc.tls_intermediate_certs;	// leave this field, too much code to change
 
 			if (doc.type !== ev.STR.PEER && doc.type !== ev.STR.ORDERER) {	// only peers and orderers have an ecert
 				delete doc.msp.component.ecert;

--- a/packages/athena/libs/component_lib.js
+++ b/packages/athena/libs/component_lib.js
@@ -86,6 +86,15 @@ module.exports = function (logger, ev, t) {
 					'component_doc.msp.ca.name',											// v3
 					'component_doc.ca_name'													// v2/internal
 				]) || undefined;
+
+				component_doc.intermediate_certs = t.misc.safe_dot_nav(component_doc, [
+					'component_doc.msp.intermediate_ca.root_certs',							// v3
+					'component_doc.intermediate_certs',										// internal
+				]) || undefined;
+				component_doc.tls_intermediate_certs = t.misc.safe_dot_nav(component_doc, [
+					'component_doc.msp.intermediate_tlsca.root_certs',						// v3
+					'component_doc.tls_intermediate_certs',									// internal
+				]) || undefined;
 			}
 
 			component_doc.config_override = component_doc.config_override || component_doc.configoverride;


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description
This pr allows identities from an intermediate CA to be available in the associate drop down.
https://github.com/hyperledger-labs/fabric-operations-console/issues/109

