### PR TITLE
fix false positive - admin identity

### DIFF
--- a/packages/apollo/.secrets.baseline
+++ b/packages/apollo/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-09-14T18:34:08Z",
+  "generated_at": "2022-01-12T21:42:54Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -13488,7 +13488,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.46.dss",
+  "version": "0.13.1+ibm.47.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/packages/apollo/src/components/IdentityExpiration/IdentityExpiration.js
+++ b/packages/apollo/src/components/IdentityExpiration/IdentityExpiration.js
@@ -72,17 +72,24 @@ class IdentityExpiration extends Component {
 
 	async checkAdmin() {
 		const msp = await this.getMsp();
-		if (msp && msp.admins) {
-			const id = await IdentityApi.getIdentity(this.props.identity);
-			let admin = false;
+		const scope = SCOPE + '_' + this.props.identity;
+		let admin = false;
+		let node_ou = _.get(msp, 'fabric_node_ous.enable', false);
+		const id = await IdentityApi.getIdentity(this.props.identity);
+		if (node_ou) {
+			const parsed = id.cert ? window.stitch.parseCertificate(id.cert) : null;
+			if (parsed && parsed.subject.indexOf('/OU=admin/') !== -1) {
+				admin = true;
+			}
+		}
+		if (!admin && msp && msp.admins) {
 			msp.admins.forEach(test => {
 				if (test === id.cert) {
 					admin = true;
 				}
 			});
-			const scope = SCOPE + '_' + this.props.identity;
-			this.props.updateState(scope, { admin });
 		}
+		this.props.updateState(scope, { admin });
 	}
 
 	render() {

--- a/packages/athena/.secrets.baseline
+++ b/packages/athena/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|apollo|stitch|test/docs|test/integration_test/integration_test_docs|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-09-14T18:34:08Z",
+  "generated_at": "2022-01-12T21:42:54Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1051,7 +1051,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.46.dss",
+  "version": "0.13.1+ibm.47.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/packages/stitch/.secrets.baseline
+++ b/packages/stitch/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-09-14T18:34:08Z",
+  "generated_at": "2022-01-12T21:42:54Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4652,7 +4652,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.46.dss",
+  "version": "0.13.1+ibm.47.dss",
   "word_list": {
     "file": null,
     "hash": null


### PR DESCRIPTION
Signed-off-by: Varad Ramamoorthy <varad@us.ibm.com>

#### Type of change

- Bug fix

#### Description
The associated identity box is still showing the 'non-admin identity' warning when configured with Node OU, but don't have the admin cert in the MSP