### PR TITLE
improve error on remove if OS has no identity

### DIFF
--- a/packages/apollo/src/assets/i18n/en/messages.json
+++ b/packages/apollo/src/assets/i18n/en/messages.json
@@ -2343,6 +2343,7 @@
 	"error_get_orderers_after_removal": "The list of orderers could not be retrieved after removing orderer.",
 	"error_remove_node_from_sys_channel_title": "System channel node remove failed",
 	"error_remove_node_from_sys_channel": "The node could not be removed from the system channel.  Nodes must be removed from the system channel before they can be deleted.",
+	"error_remove_from_sys_channel_os_identity": "The node could not be removed from the system channel.  An associated identity must be given for the ordering service.",
 	"cancel_channel_creation": "Cancel channel creation",
 	"empty_consortium_title": "No consortium members available",
 	"empty_orderer_admins_title": "No ordering service administrators available",

--- a/packages/apollo/src/components/OrdererModal/OrdererModal.js
+++ b/packages/apollo/src/components/OrdererModal/OrdererModal.js
@@ -480,6 +480,15 @@ class OrdererModal extends React.Component {
 					message: error.stitch_msg || error,
 				};
 				throw e;
+			} else if(error && error.message && error.message.includes('Missing an argument - client certificate')){
+				this.props.updateState(SCOPE, { ordererModalType: 'force_delete' });
+				const e = new Error(`Failed to remove nodes from system channel because missing an associated OS identity: ${error && (error.message || error.stitch_msg)}`);
+				e.name = 'SYSTEM_CHANNEL_NODE_REMOVAL_FAILED';
+				e.translation = {
+					title: 'error_remove_node_from_sys_channel_title',
+					message: 'error_remove_from_sys_channel_os_identity',
+				};
+				throw e;
 			} else {
 				// todo move this error down into the library itself
 				this.props.updateState(SCOPE, { ordererModalType: 'force_delete' });

--- a/packages/apollo/src/components/OrdererModal/OrdererModal.js
+++ b/packages/apollo/src/components/OrdererModal/OrdererModal.js
@@ -480,7 +480,7 @@ class OrdererModal extends React.Component {
 					message: error.stitch_msg || error,
 				};
 				throw e;
-			} else if(error && error.message && error.message.includes('Missing an argument - client certificate')){
+			} else if (error && error.message && error.message.includes('Missing an argument - client certificate')) {
 				this.props.updateState(SCOPE, { ordererModalType: 'force_delete' });
 				const e = new Error(`Failed to remove nodes from system channel because missing an associated OS identity: ${error && (error.message || error.stitch_msg)}`);
 				e.name = 'SYSTEM_CHANNEL_NODE_REMOVAL_FAILED';


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement 

#### Description
Improves the error message if you try to remove an OS with no identity associated with the OS nodes.

