### PR TITLE
fix peer list associated with orgs - intermediate ca

### DIFF
--- a/packages/apollo/src/components/OrganizationDetails/OrganizationDetails.js
+++ b/packages/apollo/src/components/OrganizationDetails/OrganizationDetails.js
@@ -110,6 +110,9 @@ class OrganizationDetails extends Component {
 				root_certs_b64pems: details.root_certs,
 				debug_tag: 'msp id: '.concat(details.id),
 			};
+			if (peer.msp_id === details.msp_id && _.isEqual(peer.msp.ca.root_certs, details.root_certs)) {
+				opts.root_certs_b64pems = Helper.safer_concat(opts.root_certs_b64pems, details.intermediate_certs);
+			}
 			let isCertAssociated = await StitchApi.isIdentityFromRootCert(opts);
 			isCertAssociated = isCertAssociated && peer.msp_id === details.msp_id;
 			Log.debug('Peer ', peer.id, ' associated with MSP ', details.id, ' ? ', isCertAssociated);


### PR DESCRIPTION
Signed-off-by: Varad Ramamoorthy <varad@us.ibm.com>

- Bug fix

Create a peer with intermediate ca
Go to "Organization" that match the peer
It does not show the peer associated with the selected org if the org is created from intermediate ca

