### PR TITLE
fix disappearing wallet

### DIFF
--- a/packages/apollo/src/components/Identities/Identities.js
+++ b/packages/apollo/src/components/Identities/Identities.js
@@ -98,7 +98,10 @@ class Identities extends Component {
 												};
 												let match = await StitchApi.isIdentityFromRootCert(data);
 												if (match) {
-													id.from_ca = id.from_ca ? id.from_ca.push(ca.name) : [ca.name];
+													if (id.from_ca === undefined) {
+														id.from_ca = [];
+													}
+													id.from_ca.push(ca.name);
 												}
 											}
 											this.resolveConnectedNodes(id, [...peers, ...orderers, ...cas]);


### PR DESCRIPTION
Signed-off-by: Varad Ramamoorthy <varad@us.ibm.com>
- Bug fix

Recreation:
Create a CA
Create Identities in Wallet

Export CA
Import CA (so that you have a copy)

Visit the Wallet page - the page goes blank