### PR TITLE
add channel info on osn drill down

### DIFF
--- a/packages/apollo/src/components/OrdererDetails/ChannelParticipationDetails.js
+++ b/packages/apollo/src/components/OrdererDetails/ChannelParticipationDetails.js
@@ -54,7 +54,7 @@ class ChannelParticipationDetails extends Component {
 		let nodes = this.props.selectedNode ? [this.props.selectedNode]:this.props.details.raft;
 		let systemChannel = true;
 		let channelInfo = {};
-		let orderer_tls_identity = await IdentityApi.getTLSIdentity(this.props.details);
+		let orderer_tls_identity = await IdentityApi.getTLSIdentity(node);
 		if (orderer_tls_identity) {
 			try {
 				let all_identity = await IdentityApi.getIdentities();

--- a/packages/apollo/src/components/OrdererDetails/ChannelParticipationDetails.js
+++ b/packages/apollo/src/components/OrdererDetails/ChannelParticipationDetails.js
@@ -50,13 +50,15 @@ class ChannelParticipationDetails extends Component {
 
 	async loadChannelData(channelId) {
 		if (this.props.details && !this.props.details.osnadmin_url) return;
+		let node = this.props.selectedNode || this.props.details;
+		let nodes = this.props.selectedNode ? [this.props.selectedNode]:this.props.details.raft;
 		let systemChannel = true;
 		let channelInfo = {};
 		let orderer_tls_identity = await IdentityApi.getTLSIdentity(this.props.details);
 		if (orderer_tls_identity) {
 			try {
 				let all_identity = await IdentityApi.getIdentities();
-				channelInfo = await ChannelParticipationApi.map1Channel(all_identity, this.props.details.raft, channelId);
+				channelInfo = await ChannelParticipationApi.map1Channel(all_identity, nodes, channelId);
 			} catch (error) {
 				Log.error('Unable to get channel list:', error);
 			}
@@ -119,6 +121,7 @@ class ChannelParticipationDetails extends Component {
 const dataProps = {
 	channelList: PropTypes.object,
 	channelInfo: PropTypes.object,
+	selectedNode: PropTypes.object,
 	showCPDetailsModal:  PropTypes.bool,
 };
 

--- a/packages/apollo/src/components/OrdererDetails/OrdererDetails.js
+++ b/packages/apollo/src/components/OrdererDetails/OrdererDetails.js
@@ -128,14 +128,15 @@ class OrdererDetails extends Component {
 	/* get channel list from channel participation api */
 	async getCPChannelList() {
 		if (this.props.details && !this.props.details.osnadmin_url) return;
+		let node = this.props.selectedNode || this.props.details;
 		let systemChannel = true;
 		let channelList = {};
 
-		let orderer_tls_identity = await IdentityApi.getTLSIdentity(this.props.details);
+		let orderer_tls_identity = await IdentityApi.getTLSIdentity(node);
 		if (orderer_tls_identity) {
 			try {
 				let all_identity = await IdentityApi.getIdentities();
-				channelList = await ChannelParticipationApi.getChannels(all_identity, this.props.details);
+				channelList = await ChannelParticipationApi.getChannels(all_identity, node);
 				if (_.get(channelList, 'systemChannel.name')) {
 					channelList.systemChannel.type = 'system_channel';
 					channelList.channels.push(channelList.systemChannel);
@@ -1356,6 +1357,7 @@ class OrdererDetails extends Component {
 													}
 													{this.props.details.osnadmin_url && this.props.orderer_tls_identity &&
 															<ChannelParticipationDetails
+																selectedNode={this.props.selectedNode}
 																channelList={this.props.channelList}
 																details={this.props.details}
 																translate={this.props.translate}
@@ -1462,6 +1464,19 @@ class OrdererDetails extends Component {
 												>
 													<NodeDetails node={this.props.selectedNode} />
 													{this.renderUsage(translate)}
+												</Tab>
+											)}
+											{this.props.selectedNode && this.props.selectedNode.osnadmin_url && (
+												<Tab
+													id="ibp-orderer-channels"
+													label={translate('channels')}
+												>
+													<ChannelParticipationDetails
+														selectedNode={this.props.selectedNode}
+														channelList={this.props.channelList}
+														details={this.props.details}
+														translate={this.props.translate}
+													/>
 												</Tab>
 											)}
 										</Tabs>


### PR DESCRIPTION
Signed-off-by: Varad Ramamoorthy <varad@us.ibm.com>

#### Type of change

- New feature
Display channel info specific to the ordering service node when drilling down