### PR TITLE
apply multipart bodyParser to the proxy route only

### DIFF
--- a/packages/athena/app.js
+++ b/packages/athena/app.js
@@ -129,7 +129,7 @@ app.use(['/api/', '/ak/'], bodyParser.text({ type: 'text/plain', limit: maxSize 
 app.use(bodyParser.json({ limit: maxSize }));
 app.use(bodyParser.urlencoded({ extended: true, limit: maxSize }));
 app.use(bodyParser.raw({ type: 'application/grpc-web+proto', limit: maxSize }));	// leave as buffer (w/o this line req.body is empty)
-app.use(bodyParser.raw({ type: 'multipart/form-data', limit: maxSize }));			// leave as buffer (w/o this line req.body is empty)
+app.use('/proxy/', bodyParser.raw({ type: 'multipart/form-data', limit: maxSize }));// leave as buffer (w/o this line req.body is empty)
 
 app.use(compression());
 look_for_couchdb(() => {


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
<!--- Describe your changes in detail, including motivation. -->

The added body parser is breaking the configtxlator proxy route. This moves that parser from the global scope to just the generic proxy route.