### PR TITLE
Stitch policy fixes

### DIFF
--- a/packages/athena/public/releaseNotes.json
+++ b/packages/athena/public/releaseNotes.json
@@ -1,7 +1,25 @@
 [
 	{
+		"version": "1.0.0-19",
+		"date": "04 March 2022",
+		"description": [
+			{
+				"title": "Bug & security fixes",
+				"details": "Miscellaneous fixes & dependency updates."
+			},
+			{
+				"title": "Fix MSP Role Builder",
+				"details": "Fixes the 'MSPRole' field building inside a chaincode definition 'validationParameter' field when a value other than 'MEMBER' is set."
+			},
+			{
+				"title": "Fix Endorsement Policy Builder",
+				"details": "Fixes the 'endorsementPolicy' field building inside a chaincode definition 'StaticCollectionConfig' field when an endorsement policy was not set."
+			}
+		]
+	},
+	{
 		"version": "1.0.0-17",
-		"date": "02 Feb 2022",
+		"date": "28 Feb 2022",
 		"description": [
 			{
 				"title": "Bug & security fixes",

--- a/packages/stitch/src/libs/proto_handlers/collection_pb_lib.ts
+++ b/packages/stitch/src/libs/proto_handlers/collection_pb_lib.ts
@@ -104,7 +104,7 @@ export class CollectionLib {
 			const endorsement_spe = endorsement_fmt ? this.policyLib.__build_signature_policy_envelope_alt(endorsement_fmt) : null;
 
 			const StaticCollectionConfig = __pb_root.lookupType('protos.StaticCollectionConfig');
-			const opts = {																	// remember protobufjs expects camelCase keys
+			const opts: any = {																	// remember protobufjs expects camelCase keys
 				name: config.name,
 				memberOrgsPolicy: this.__build_collection_policy_config(private_data_spe),	// build message for field
 				requiredPeerCount: config.required_peer_count,
@@ -112,11 +112,14 @@ export class CollectionLib {
 				blockToLive: config.block_to_live,
 				memberOnlyRead: config.member_only_read,
 				memberOnlyWrite: config.member_only_write,
-				endorsementPolicy: this.policyLib.__build_application_policy(				// build message for field
-					endorsement_spe,
-					config.endorsement_policy ? config.endorsement_policy.channel_config_policy_reference : null
-				),
+				//endorsementPolicy: null									// don't set endorsementPolicy unless given
 			};
+			if (endorsement_spe || (config.endorsement_policy && config.endorsement_policy.channel_config_policy_reference)) {
+				opts.endorsementPolicy = this.policyLib.__build_application_policy(
+					endorsement_spe,										// only one of these should be set
+					config.endorsement_policy ? config.endorsement_policy.channel_config_policy_reference : null
+				);
+			}
 			let message = StaticCollectionConfig.create(opts);
 			return StaticCollectionConfig.toObject(message, { defaults: true });
 		}

--- a/packages/stitch/src/libs/proto_handlers/policy_pb_lib.ts
+++ b/packages/stitch/src/libs/proto_handlers/policy_pb_lib.ts
@@ -170,7 +170,7 @@ export class PolicyLib {
 			principalClassification: opts.principal_classification,			// remember this protobufjs expects camelCase keys
 			principal: opts.b_principal
 		};
-		let message = MSPPrincipal.create(p_opts);
+		let message = MSPPrincipal.fromObject(p_opts);
 		return message;
 	}
 

--- a/packages/stitch/src/stitch.ts
+++ b/packages/stitch/src/stitch.ts
@@ -104,7 +104,7 @@ export {
 	pem2raw, exportJwkKey, exportHexKey, subtleVerifySignature, jwk2pem, exportPemKey, build_sig_collection_for_hash, scSignJwkRaw, scGenCSR,
 	test_encodeDecode_collection_config_packaged, load_pb, switchEncryption, encrypt, decrypt, DER_signAndPackCsrPem, DER_parsePem, getOrGenAesKey,
 	convertPolicy2PeerCliSyntax, policyIsMet, safer_hex_str, url_join, lifecycleLib, decode_chaincode_query_response, Query_ChannelQueryResponse,
-	Ledger_BlockchainInfo
+	Ledger_BlockchainInfo, policyLib,
 };
 
 // proto handlers

--- a/packages/stitch/test/stitch.test.js
+++ b/packages/stitch/test/stitch.test.js
@@ -967,7 +967,7 @@ describe('testing', function () {
 					'\b\u0000\u0012\b\u0012\u0006\b\u0001\u0012\u0002\b\u0000\u001a\u0010\b\u0000\u0012\f\n\bPeerOrg1\u0010\u0001',
 					'',
 					'',
-					'\n:\n8\n\bmyPolicy\u0012 \n\u001e\b\u0000\u0012\b\u0012\u0006\b\u0001\u0012\u0002\b\u0000\u001a\u0010\b\u0000\u0012\f\n\bPeerOrg1\u0010\u0001\u0018\u0002 \u0004(\u00000\u00008\u0000B\u0000'	// eslint-disable-line max-len
+					'\n8\n6\n\bmyPolicy\u0012 \n\u001e\b\u0000\u0012\b\u0012\u0006\b\u0001\u0012\u0002\b\u0000\u001a\u0010\b\u0000\u0012\f\n\bPeerOrg1\u0010\u0001\u0018\u0002 \u0004(\u00000\u00008\u0000'	// eslint-disable-line max-len
 				],
 				'transientMap': null
 			};
@@ -1041,7 +1041,7 @@ describe('testing', function () {
 					'\b\u0000\u0012\f\u0012\n\b\u0001\u0012\u0002\b\u0000\u0012\u0002\b\u0001\u001a\u0010\b\u0000\u0012\f\n\bPeerOrg1\u0010\u0000',
 					'',
 					'',
-					'\n:\n8\n\bmyPolicy\u0012 \n\u001e\b\u0000\u0012\b\u0012\u0006\b\u0001\u0012\u0002\b\u0000\u001a\u0010\b\u0000\u0012\f\n\bPeerOrg1\u0010\u0000\u0018\u0002 \u0004(\u00000\u00008\u0000B\u0000'	// eslint-disable-line max-len
+					'\n8\n6\n\bmyPolicy\u0012 \n\u001e\b\u0000\u0012\b\u0012\u0006\b\u0001\u0012\u0002\b\u0000\u001a\u0010\b\u0000\u0012\f\n\bPeerOrg1\u0010\u0000\u0018\u0002 \u0004(\u00000\u00008\u0000'
 				],
 				'transientMap': null
 			};
@@ -1115,7 +1115,7 @@ describe('testing', function () {
 					'\b\u0000\u0012\f\u0012\n\b\u0001\u0012\u0002\b\u0000\u0012\u0002\b\u0001\u001a\u0010\b\u0000\u0012\f\n\bPeerOrg1\u0010\u0000',
 					'',
 					'',
-					'\n:\n8\n\bmyPolicy\u0012 \n\u001e\b\u0000\u0012\b\u0012\u0006\b\u0001\u0012\u0002\b\u0000\u001a\u0010\b\u0000\u0012\f\n\bPeerOrg1\u0010\u0000\u0018\u0002 \u0004(\u00000\u00008\u0000B\u0000'	// eslint-disable-line max-len
+					'\n8\n6\n\bmyPolicy\u0012 \n\u001e\b\u0000\u0012\b\u0012\u0006\b\u0001\u0012\u0002\b\u0000\u001a\u0010\b\u0000\u0012\f\n\bPeerOrg1\u0010\u0000\u0018\u0002 \u0004(\u00000\u00008\u0000'
 				],
 				'transientMap': null
 			};
@@ -1231,7 +1231,7 @@ describe('testing', function () {
 					'\b\u0000\u0012\f\u0012\n\b\u0001\u0012\u0002\b\u0000\u0012\u0002\b\u0001\u001a\u0010\b\u0000\u0012\f\n\bPeerOrg1\u0010\u0000',
 					'',
 					'',
-					'\n:\n8\n\bmyPolicy\u0012 \n\u001e\b\u0000\u0012\b\u0012\u0006\b\u0001\u0012\u0002\b\u0000\u001a\u0010\b\u0000\u0012\f\n\bPeerOrg1\u0010\u0000\u0018\u0002 \u0004(\u00000\u00008\u0000B\u0000',	// eslint-disable-line max-len
+					'\n8\n6\n\bmyPolicy\u0012 \n\u001e\b\u0000\u0012\b\u0012\u0006\b\u0001\u0012\u0002\b\u0000\u001a\u0010\b\u0000\u0012\f\n\bPeerOrg1\u0010\u0000\u0018\u0002 \u0004(\u00000\u00008\u0000'
 				],
 				'transientMap': null
 			};
@@ -2521,7 +2521,7 @@ yJMfGXHykKD1d2F+B58=
 								'blockToLive': opts.block_to_live,
 								'memberOnlyRead': opts.member_only_read,
 								'memberOnlyWrite': opts.member_only_write,
-								'endorsementPolicy': {}
+								'endorsementPolicy': null
 							}
 						}
 					]
@@ -2591,7 +2591,7 @@ yJMfGXHykKD1d2F+B58=
 								'blockToLive': opts.block_to_live,
 								'memberOnlyRead': opts.member_only_read,
 								'memberOnlyWrite': opts.member_only_write,
-								'endorsementPolicy': {}
+								'endorsementPolicy': null
 							}
 						}
 					]
@@ -2671,7 +2671,7 @@ yJMfGXHykKD1d2F+B58=
 								'blockToLive': opts.block_to_live,
 								'memberOnlyRead': opts.member_only_read,
 								'memberOnlyWrite': opts.member_only_write,
-								'endorsementPolicy': {}
+								'endorsementPolicy': null
 							}
 						}
 					]
@@ -2779,7 +2779,7 @@ yJMfGXHykKD1d2F+B58=
 								'blockToLive': opts.block_to_live,
 								'memberOnlyRead': opts.member_only_read,
 								'memberOnlyWrite': opts.member_only_write,
-								'endorsementPolicy': {}
+								'endorsementPolicy': null
 							}
 						}
 					]
@@ -3166,7 +3166,7 @@ yJMfGXHykKD1d2F+B58=
 								'blockToLive': opts.block_to_live,
 								'memberOnlyRead': opts.member_only_read,
 								'memberOnlyWrite': opts.member_only_write,
-								'endorsementPolicy': {}
+								'endorsementPolicy': null
 							}
 						}
 					]
@@ -3265,7 +3265,7 @@ yJMfGXHykKD1d2F+B58=
 								'blockToLive': opts.block_to_live,
 								'memberOnlyRead': opts.member_only_read,
 								'memberOnlyWrite': opts.member_only_write,
-								'endorsementPolicy': {}
+								'endorsementPolicy': null
 							}
 						}
 					]
@@ -4093,6 +4093,68 @@ yJMfGXHykKD1d2F+B58=
 			const url2 = '/something/here';
 			expect(stitch.url_join(url1, url2)).to.equal(url1 + url2);
 			done();
+		});
+	});
+
+	describe('MSP Role', () => {
+		it(getId() + 'should return MSP role with the correct ROLE enum string - PEER', (done) => {
+			stitch.load_pb((__pb_root) => {
+				const MSPRole = __pb_root.lookupType('common.MSPRole');
+				let msp_opts = {
+					mspIdentifier: 'msp1',
+					role: 'PEER',
+				};
+				const b_mspRole = stitch.policyLib.__b_build_msp_role(msp_opts);
+				let msg2 = MSPRole.decode(b_mspRole);
+				let obj = MSPRole.toObject(msg2, { defaults: false });
+				expect(obj).to.deep.equal({ mspIdentifier: 'msp1', role: 3 });
+				done();
+			});
+		});
+
+		it(getId() + 'should return MSP role with the correct ROLE enum string - ADMIN', (done) => {
+			stitch.load_pb((__pb_root) => {
+				const MSPRole = __pb_root.lookupType('common.MSPRole');
+				let msp_opts = {
+					mspIdentifier: 'msp2',
+					role: 'ADMIN',
+				};
+				const b_mspRole = stitch.policyLib.__b_build_msp_role(msp_opts);
+				let msg2 = MSPRole.decode(b_mspRole);
+				let obj = MSPRole.toObject(msg2, { defaults: false });
+				expect(obj).to.deep.equal({ mspIdentifier: 'msp2', role: 1 });
+				done();
+			});
+		});
+
+		it(getId() + 'should return MSP role with the correct ROLE enum string - lc admin', (done) => {
+			stitch.load_pb((__pb_root) => {
+				const MSPRole = __pb_root.lookupType('common.MSPRole');
+				let msp_opts = {
+					mspIdentifier: 'msp3',
+					role: 'admin',
+				};
+				const b_mspRole = stitch.policyLib.__b_build_msp_role(msp_opts);
+				let msg2 = MSPRole.decode(b_mspRole);
+				let obj = MSPRole.toObject(msg2, { defaults: false });
+				expect(obj).to.deep.equal({ mspIdentifier: 'msp3', role: 1 });
+				done();
+			});
+		});
+
+		it(getId() + 'should return MSP role with the correct ROLE enum string - MEMBER', (done) => {
+			stitch.load_pb((__pb_root) => {
+				const MSPRole = __pb_root.lookupType('common.MSPRole');
+				let msp_opts = {
+					mspIdentifier: 'msp3',
+					role: 'MEMBER',
+				};
+				const b_mspRole = stitch.policyLib.__b_build_msp_role(msp_opts);
+				let msg2 = MSPRole.decode(b_mspRole);
+				let obj = MSPRole.toObject(msg2, { defaults: false });
+				expect(obj).to.deep.equal({ mspIdentifier: 'msp3', role: 0 });
+				done();
+			});
 		});
 	});
 


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
- fix MSP Role formatting in a chaincode definition, was always being set to `MEMBER`
- remove an empty `endorsementPolicy` if a endorsment policy was not set in a Static Collection Config

