### PR TITLE
lower component resource limits & requests

### DIFF
--- a/packages/athena/json_docs/json_validation/ibp_openapi_v2.yaml
+++ b/packages/athena/json_docs/json_validation/ibp_openapi_v2.yaml
@@ -8285,14 +8285,14 @@ components:
           example: 100m
           x-validate_cpu: true
           x-minimum: 0.01
-          x-maximum: 1000
+          x-maximum: 100
           description: Desired CPU for subcomponent. [Resource details](/docs/blockchain?topic=blockchain-ibp-console-govern-components#ibp-console-govern-components-allocate-resources)
         memory:
           type: string
           example: 256MiB
           x-validate_memory: true
           x-minimum: 1
-          x-maximum: 1099511627776
+          x-maximum: 107374182400
           description: Desired memory for subcomponent. [Resource details](/docs/blockchain?topic=blockchain-ibp-console-govern-components#ibp-console-govern-components-allocate-resources)
 
     ResourceLimits:
@@ -8303,14 +8303,14 @@ components:
           example: 100m
           x-validate_cpu: true
           x-minimum: 0.01
-          x-maximum: 1000
+          x-maximum: 100
           description: Maximum CPU for subcomponent. Must be >= "requests.cpu". Defaults to the same value in "requests.cpu". [Resource details](/docs/blockchain?topic=blockchain-ibp-console-govern-components#ibp-console-govern-components-allocate-resources)
         memory:
           type: string
           example: 256MiB
           x-validate_memory: true
           x-minimum: 1
-          x-maximum: 1099511627776
+          x-maximum: 107374182400
           description: Maximum memory for subcomponent. Must be >= "requests.memory". Defaults to the same value in "requests.memory". [Resource details](/docs/blockchain?topic=blockchain-ibp-console-govern-components#ibp-console-govern-components-allocate-resources)
 
     StorageObject:
@@ -8320,7 +8320,7 @@ components:
           type: string
           example: 4GiB
           x-minimum: 1
-          x-maximum: 1125899906842624
+          x-maximum: 10995116277760
           x-validate_storage: true
           description: Maximum disk space for subcomponent. [Resource details](/docs/blockchain?topic=blockchain-ibp-console-govern-components#ibp-console-govern-components-allocate-resources)
         class:

--- a/packages/athena/json_docs/json_validation/ibp_openapi_v3.yaml
+++ b/packages/athena/json_docs/json_validation/ibp_openapi_v3.yaml
@@ -15471,14 +15471,14 @@ components:
           example: 100m
           x-validate_cpu: true
           x-minimum: 0.01
-          x-maximum: 1000
+          x-maximum: 100
           description: Desired CPU for subcomponent. [Resource details](/docs/blockchain?topic=blockchain-ibp-console-govern-components#ibp-console-govern-components-allocate-resources)
         memory:
           type: string
           example: 256MiB
           x-validate_memory: true
           x-minimum: 1
-          x-maximum: 1099511627776
+          x-maximum: 107374182400
           description: Desired memory for subcomponent. [Resource details](/docs/blockchain?topic=blockchain-ibp-console-govern-components#ibp-console-govern-components-allocate-resources)
 
     ResourceLimits:
@@ -15489,14 +15489,14 @@ components:
           example: 100m
           x-validate_cpu: true
           x-minimum: 0.01
-          x-maximum: 1000
+          x-maximum: 100
           description: Maximum CPU for subcomponent. Must be >= "requests.cpu". Defaults to the same value in "requests.cpu". [Resource details](/docs/blockchain?topic=blockchain-ibp-console-govern-components#ibp-console-govern-components-allocate-resources)
         memory:
           type: string
           example: 256MiB
           x-validate_memory: true
           x-minimum: 1
-          x-maximum: 1099511627776
+          x-maximum: 107374182400
           description: Maximum memory for subcomponent. Must be >= "requests.memory". Defaults to the same value in "requests.memory". [Resource details](/docs/blockchain?topic=blockchain-ibp-console-govern-components#ibp-console-govern-components-allocate-resources)
 
     StorageObject:
@@ -15506,7 +15506,7 @@ components:
           type: string
           example: 4GiB
           x-minimum: 1
-          x-maximum: 1125899906842624
+          x-maximum: 10995116277760
           x-validate_storage: true
           description: Maximum disk space for subcomponent. [Resource details](/docs/blockchain?topic=blockchain-ibp-console-govern-components#ibp-console-govern-components-allocate-resources)
         class:


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

- Improvement


#### Description
Lower the maximum resource limits on a deployed component:
- CPU max was 1000, now 100
- Memory max was 1TB, now 100GB
- Storage max was 1PB, now 10TB

