### PR TITLE
Tweak pass submit button

### DIFF
--- a/packages/apollo/src/assets/i18n/en/messages.json
+++ b/packages/apollo/src/assets/i18n/en/messages.json
@@ -1659,7 +1659,7 @@
 	"reset_password": "Reset password",
 	"reset_email": "Email",
 	"reset_email_placeholder": "Enter email of the user",
-	"reset_password_successful": "Password for ${user} was successfully reset to ${password}.",
+	"reset_password_successful": "Password for ${user} was reset to the default password.",
 	"reset_password_failed": "Password reset failed.",
 	"change_password": "Change password",
 	"change_password_successful": "Password changed successfully.",

--- a/packages/apollo/src/assets/i18n/en/messages.json
+++ b/packages/apollo/src/assets/i18n/en/messages.json
@@ -1659,7 +1659,7 @@
 	"reset_password": "Reset password",
 	"reset_email": "Email",
 	"reset_email_placeholder": "Enter email of the user",
-	"reset_password_successful": "Password for ${user} was reset to the default password.",
+	"reset_password_successful": "Password for '${user}' was reset to the default password.",
 	"reset_password_failed": "Password reset failed.",
 	"change_password": "Change password",
 	"change_password_successful": "Password changed successfully.",

--- a/packages/apollo/src/components/ChangePasswordModal/ChangePasswordModal.js
+++ b/packages/apollo/src/components/ChangePasswordModal/ChangePasswordModal.js
@@ -115,7 +115,8 @@ class ChangePasswordModal extends Component {
 			!this.props.newPassword ||
 			!this.props.confirmPassword ||
 			this.props.newPassword !== this.props.confirmPassword ||
-			this.props.newPassword.length < 8;
+			this.props.newPasswordError !== '';
+
 		const translate = this.props.translate;
 		return (
 			<div>

--- a/packages/apollo/src/components/Login/Login.js
+++ b/packages/apollo/src/components/Login/Login.js
@@ -131,7 +131,7 @@ export class Login extends Component {
 
 		// changing the password
 		if (this.props.changePassword) {
-			if (!this.props.currentPassword || !this.props.confirmPassword) {	// passwords must be set
+			if (!this.props.currentPassword || !this.props.newPassword || !this.props.confirmPassword) {	// passwords must be set
 				disableSubmit = true;
 			}
 			if (this.props.newPassword !== this.props.confirmPassword) {		// must match

--- a/packages/apollo/src/components/Login/Login.js
+++ b/packages/apollo/src/components/Login/Login.js
@@ -128,17 +128,27 @@ export class Login extends Component {
 
 	render() {
 		let disableSubmit = false;
-		if (
-			(this.props.changePassword &&
-				(!this.props.currentPassword ||
-					!this.props.newPassword ||
-					!this.props.confirmPassword ||
-					this.props.newPassword !== this.props.confirmPassword ||
-					this.props.newPassword.length < 8)) ||
-			(!this.props.changePassword && (!this.props.email || !this.props.login_password))
-		) {
-			disableSubmit = true;
+
+		// changing the password
+		if (this.props.changePassword) {
+			if (!this.props.currentPassword || !this.props.confirmPassword) {	// passwords must be set
+				disableSubmit = true;
+			}
+			if (this.props.newPassword !== this.props.confirmPassword) {		// must match
+				disableSubmit = true;
+			}
+			if (this.props.newPasswordError !== '') {							// can't have new pass errors
+				disableSubmit = true;
+			}
 		}
+
+		// normal login
+		else {
+			if (!this.props.email || !this.props.login_password) {
+				disableSubmit = true;
+			}
+		}
+
 		const translate = this.props.translate;
 		return (
 			<Router>

--- a/packages/apollo/src/components/Members/Members.js
+++ b/packages/apollo/src/components/Members/Members.js
@@ -287,7 +287,7 @@ export class Members extends Component {
 								user={this.props.user}
 								onClose={this.closeResetPasswordModal}
 								onComplete={response => {
-									this.props.showSuccess('reset_password_successful', { user: response.user, password: response.password }, SCOPE);
+									this.props.showSuccess('reset_password_successful', { user: response.user }, SCOPE);
 								}}
 							/>
 						)}

--- a/packages/apollo/src/components/ReleaseNotes/ReleaseNotes.js
+++ b/packages/apollo/src/components/ReleaseNotes/ReleaseNotes.js
@@ -69,7 +69,7 @@ const ReleaseNotes = props => {
 														{' '}
 														<div className="ibp-note-bullet-point">-</div>
 														<div className="ibp-note-bullet-text">
-															<strong>{desc.title} </strong>
+															<strong>{desc.title}: </strong>
 															<span>{desc.details}</span>
 														</div>
 													</li>

--- a/packages/apollo/src/components/ReleaseNotes/_releaseNotes.scss
+++ b/packages/apollo/src/components/ReleaseNotes/_releaseNotes.scss
@@ -27,7 +27,7 @@
 }
 
 .ibp-note-table-container {
-	max-height: 50rem;
+	max-height: 25rem;
 	overflow-y: auto;
 }
 

--- a/packages/apollo/test/unit/tests/Login.test.jsx
+++ b/packages/apollo/test/unit/tests/Login.test.jsx
@@ -175,10 +175,12 @@ describe('Login component', () => {
 		});
 
 		it('should render for changing password', () => {
+			const newPass = 'iwenttothestoretobuymilk';		// dummy password please ignore
 			props.changePassword = true;
 			props.currentPassword = 'password';
-			props.newPassword = 'iwenttothestoretobuymilk';		// dummy password please ignore
-			props.confirmPassword = 'iwenttothestoretobuymilk';	// dummy password please ignore
+			props.newPassword = newPass;
+			props.confirmPassword = newPass;
+			props.newPasswordError = '';
 
 			const component = mount(<Login {...props} />);
 			component

--- a/packages/apollo/test/unit/tests/Login.test.jsx
+++ b/packages/apollo/test/unit/tests/Login.test.jsx
@@ -177,8 +177,8 @@ describe('Login component', () => {
 		it('should render for changing password', () => {
 			props.changePassword = true;
 			props.currentPassword = 'password';
-			props.newPassword = 'password';
-			props.confirmPassword = 'password';
+			props.newPassword = 'iwenttothestoretobuymilk';		// dummy password please ignore
+			props.confirmPassword = 'iwenttothestoretobuymilk';	// dummy password please ignore
 
 			const component = mount(<Login {...props} />);
 			component

--- a/packages/athena/public/releaseNotes.json
+++ b/packages/athena/public/releaseNotes.json
@@ -1,5 +1,27 @@
 [
 	{
+		"version": "1.0.0-21",
+		"date": "25 March 2022",
+		"description": [
+			{
+				"title": "Bug & security fixes",
+				"details": "Miscellaneous fixes & dependency updates."
+			},
+			{
+				"title": "New Password Rules",
+				"details": "New login passwords must pass OWASP strength tests. [Passwords <= 9 char] not allowed. [Passwords >= 10 && < 20 char] - must have lowercase & uppercase & special characters. [Passwords >= 20 char] - no extra rules."
+			},
+			{
+				"title": "Lower Component Limit",
+				"details": "The maximum component limit has been lowered from 250 components to 75. This restriction applies to the total number of peers + orderers + CAs on 1 console."
+			},
+			{
+				"title": "Lower Resource Limits",
+				"details": "The maximum CPU, memory and storage resource limits *per* component has been lowered. New limits: CPU - 100, Memory - 100GB, Storage - 10TB."
+			}
+		]
+	},
+	{
 		"version": "1.0.0-19",
 		"date": "04 March 2022",
 		"description": [


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
- The reset password modal was allowing a user to click submit even if there were password strength errors.  The password was still being rejected, but disabling the submit button is the desired behavior.
- Adds release notes

