### PR TITLE
validate CA enrollment host during create peer/os

### DIFF
--- a/packages/athena/json_docs/json_validation/ibp_openapi_v2.yaml
+++ b/packages/athena/json_docs/json_validation/ibp_openapi_v2.yaml
@@ -132,6 +132,10 @@ x-validate_error_messages:
 
   # it is invalid to set this field if using a free k8s plan - doesn't apply to IBP software
   invalid_key_on_free_plan: "A *free* IBM Cloud Kubernetes cluster cannot use the parameter '$PROPERTY_NAME'."
+
+  # this value must be a known hostname, typically from an imported or deployed CA
+  unknown_enroll_host: "The parameter '$PROPERTY_NAME' was not found in the list of known hostnames. Import the CA using this hostname or use a hostname that is already known."
+
 #
 #
 #
@@ -4710,8 +4714,9 @@ components:
     cahost:
       type: string
       example: n3a3ec3-myca.ibp.us-south.containers.appdomain.cloud
-      description: The CA's hostname. Do not include protocol or port.
+      description: The CA's hostname. Do not include protocol or port. Must be a hostname from a known CA.
       maxLength: 1024 # spam prevention limit
+      x-validate_known_hostname: true
     caport:
       type: number
       example: 7054

--- a/packages/athena/json_docs/json_validation/ibp_openapi_v3.yaml
+++ b/packages/athena/json_docs/json_validation/ibp_openapi_v3.yaml
@@ -140,6 +140,10 @@ x-validate_error_messages:
 
   # it is invalid to set more than 1 key in this body
   too_many_keys: "Too many fields in body. This API only supports 1 field in the body. Use multiple apis to update multiple fields."
+
+  # this value must be a known hostname, typically from an imported or deployed CA
+  unknown_enroll_host: "The parameter '$PROPERTY_NAME' was not found in the list of known hostnames. Import the CA using this hostname or use a hostname that is already known."
+
 #
 #
 #
@@ -11440,8 +11444,9 @@ components:
     cahost:
       type: string
       example: n3a3ec3-myca.ibp.us-south.containers.appdomain.cloud
-      description: The CA's hostname. Do not include protocol or port.
+      description: The CA's hostname. Do not include protocol or port. Must be a hostname from a known CA.
       maxLength: 1024 # spam prevention limit
+      x-validate_known_hostname: true
     caport:
       type: number
       example: 7054

--- a/packages/athena/libs/validation_lib.js
+++ b/packages/athena/libs/validation_lib.js
@@ -94,6 +94,9 @@
 		- string -> "ak" or "all". applies to keys in an object type. this means to only allow 1 root field in the object.
 		- a value of "ak" means this restriction only applies to api key routes (/ak/ routes).
 		- a value of "all" means this restriction applies to /ak/ and internal (apollo) routes.
+	x-validate_known_hostname:
+		- string. applies to enrollment "host" fields when deploying components
+		- will generate an error if this hostname is not in the whitelist
 */
 module.exports = (logger, ev, t, opts) => {
 	const validate = {};
@@ -741,6 +744,16 @@ module.exports = (logger, ev, t, opts) => {
 			if (typeof input === 'object' && Object.keys(input).length > 1) {
 				const symbols = {};
 				errors.push({ key: 'too_many_keys', symbols: symbols });
+			}
+		}
+
+		// check if the hostname is in our whitelist or not
+		if (body_spec['x-validate_known_hostname'] === true) {
+			if (!t.ot_misc.validateUrl(input, ev.HOST_WHITE_LIST)) {
+				const symbols = {
+					'$PROPERTY_NAME': path2field.join('.'),
+				};
+				errors.push({ key: 'unknown_enroll_host', symbols: symbols });
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement (safety)

#### Description
- will reject apis to create a peer or orderer using an unknown CA hostname. 
  - failures generate: `The parameter 'crypto.enrollment.ca.host' was not found in the list of known hostnames. Import the CA using this hostname or use a hostname that is already known.`

