### PR TITLE
Fix signature auth - channel creation

### DIFF
--- a/packages/apollo/src/components/ChannelModal/ChannelModal.js
+++ b/packages/apollo/src/components/ChannelModal/ChannelModal.js
@@ -1827,6 +1827,7 @@ class ChannelModal extends Component {
 			orderer_msp: this.props.selectedOrderer.msp_id,
 			client_cert_b64pem: this.props.selectedIdentity ? this.props.selectedIdentity.cert : null,
 			client_prv_key_b64pem: this.props.selectedIdentity ? this.props.selectedIdentity.private_key : null,
+			org_msp_id: this.props.selectedChannelCreator ? this.props.selectedChannelCreator.msp_id : null,
 			configtxlator_url: this.props.configtxlator_url,
 			acls: acls,
 			n_out_of: this.props.customPolicy ? this.props.customPolicy.id : 1,

--- a/packages/apollo/src/components/ChannelModal/ChannelModal.js
+++ b/packages/apollo/src/components/ChannelModal/ChannelModal.js
@@ -1794,15 +1794,7 @@ class ChannelModal extends Component {
 				tick_interval: this.props.tick_interval, */
 			};
 		}
-		let selectedOrdererCapability =
-			(this.props.selectedOrdererCapability && typeof this.props.selectedOrdererCapability === 'object' && this.props.selectedOrdererCapability.id !== 'use_default') ?
-				this.props.selectedOrdererCapability.id : this.getDefaultCap('orderer');
-		let selectedChannelCapability =
-			(this.props.selectedChannelCapability && typeof this.props.selectedChannelCapability === 'object' && this.props.selectedChannelCapability.id !== 'use_default') ?
-				this.props.selectedChannelCapability.id : this.getDefaultCap('channel');;
-		let selectedApplicationCapability =
-			(this.props.selectedApplicationCapability && typeof this.props.selectedApplicationCapability === 'object' && this.props.selectedApplicationCapability.id !== 'use_default') ?
-				this.props.selectedApplicationCapability.id : this.getDefaultCap('application');
+
 		let orderer_urls = [];
 		if (this.isConsenterSetModified() && _.has(this.props.selectedOrderer, 'raft')) {
 			this.props.selectedOrderer.raft.forEach(node => {
@@ -1835,21 +1827,33 @@ class ChannelModal extends Component {
 			block_params: block_params,
 			raft_params: raft_params,
 			consenters: this.decideConsenters(),
+			application_capabilities: this.setCapValue(this.props.selectedApplicationCapability, 'application'),		// this is sometimes null
+			orderer_capabilities: this.setCapValue(this.props.selectedOrdererCapability, 'orderer'),					// this is sometimes null
+			channel_capabilities: this.setCapValue(this.props.selectedChannelCapability, 'channel'),					// this is sometimes null
 		};
-		if (selectedApplicationCapability) {
-			options.application_capabilities = [selectedApplicationCapability];
-		}
-		if (selectedChannelCapability) {
-			options.channel_capabilities = [selectedChannelCapability];
-		}
-		if (selectedOrdererCapability) {
-			options.orderer_capabilities = [selectedOrdererCapability];
-		}
-		if (selectedApplicationCapability && selectedApplicationCapability.indexOf('V2_0') !== -1) {
+
+		if (options.application_capabilities && options.application_capabilities.includes('V2_0')) {
 			this.buildChaincodePolicyOptions(options, 'lifecycle_policy');
 			this.buildChaincodePolicyOptions(options, 'endorsement_policy');
 		}
+
 		return options;
+	}
+
+	// only set capability if using osnadmin OR if a non-default cap was chosen, else return null.
+	// - its important to return null here b/c otherwise we will think an orderer-signature is needed downstream, even on a create-channel-call which is wrong and leads to errors.
+	setCapValue = (selectedCapField, defaultCapFieldName) => {
+		// set this variable if one was selected, if using a default leave it as null
+		let selectedCapability =
+			(selectedCapField && typeof selectedCapField === 'object' && selectedCapField.id !== 'use_default') ? selectedCapField.id : null;
+
+		if (selectedCapability) {
+			return [selectedCapability];				// return selected cap as an array
+		} else if (this.props.use_osnadmin) {
+			this.getDefaultCap(defaultCapFieldName);	// return the default cap if using the osnadmin feature
+		} else {
+			return null;								// return null for other cases
+		}
 	}
 
 	// runs the legacy create channel api

--- a/packages/apollo/src/components/Channels/Channels.js
+++ b/packages/apollo/src/components/Channels/Channels.js
@@ -138,6 +138,7 @@ class ChannelComponent extends Component {
 			if (!this.mounted) {
 				return;
 			}
+
 			// Build list that includes all raft nodes from all the console ordering services
 			let all_nodes = [];
 			orderers.forEach(orderer => {
@@ -148,8 +149,8 @@ class ChannelComponent extends Component {
 				}
 			});
 
-			const pendingChannels = [];
 			// Get pending channels from notifications instead of local storage
+			const pendingChannels = [];
 			let signature_requests = await this.getCreateChannelRequests();
 			signature_requests.forEach(notification => {
 				let notification_orderers = [];

--- a/packages/athena/json_docs/json_validation/ibp_openapi_v3.yaml
+++ b/packages/athena/json_docs/json_validation/ibp_openapi_v3.yaml
@@ -13467,6 +13467,7 @@ components:
             couchDBConfig:
               type: object
               x-validate_no_extra_keys: true
+              x-validate_case_insensitive: true
               properties:
                 cacheSize:
                   description: Maximum size of the cache for CouchDB operations in MB. Defaults to 64MB. Note that if the cache size is not a multiple of 32 MB, the peer will round the size to the next multiple of 32MB.

--- a/packages/athena/libs/signature_collection_lib.js
+++ b/packages/athena/libs/signature_collection_lib.js
@@ -1377,8 +1377,12 @@ module.exports = function (logger, ev, t) {
 							root_certs_b64: exports.getCertsForMspId(allPartyData, msp_id),
 							debug_tag: 'sig collection signature',
 						};
+						if (!msp_id) {
+							logger.error('[auth sig collection] field "msp_id" is missing from "authorize". will be unable to verify signature.');
+						}
 						if (!t.misc.is_trusted_certificate(options)) {
-							logger.error('[auth sig collection] no root certs signed provided cert for scs. signature is not trusted', msp_id);
+							logger.error('[auth sig collection] cert that created scs is not trusted by any known root certs. sig not trusted. msp:', msp_id);
+							logger.debug('[auth sig collection] number of trusted certs for msp:', options.root_certs_b64.length, 'msp:', msp_id);
 							return send_unauthorized('unauthorized - untrusted signature (scs)');
 						} else {
 							logger.info('[validate cert] sig collection signature certificate validated with a root cert - step:[2/2]');


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
 - Fixed an issue with a missing msp id that fails to build a proper signature authorize field. Happens during channel creation.
 - Adds some server side logs to help identify the missing msp id issue
 - Adds case sensitive flag to fabric gateway config-override validation (unrelated to channel issue)
 - Fixed issue where the application/orderer/channel capabilities were being set on a create-channel flow causing create failures.

