### PR TITLE
do not run k8s sync w/cached deployer data

### DIFF
--- a/packages/athena/libs/deployer_lib.js
+++ b/packages/athena/libs/deployer_lib.js
@@ -1165,7 +1165,7 @@ module.exports = function (logger, ev, t) {
 					athena_docs: athena_data ? athena_data.components : null,		// pass athena docs on too, useful
 					deployer_data: deployer_data,
 				};
-				if (!deployer_data._cached) {										// do not run sync w/cached deployer data
+				if (deployer_data && !deployer_data._cached) {						// do not run sync w/cached deployer data
 					batch_sync_deployer_attributes_with_couch(ret);					// we don't wait on batch sync... todo re-evaluate
 				}
 				return cb(null, ret);
@@ -1328,7 +1328,7 @@ module.exports = function (logger, ev, t) {
 				if (ret.deployer_data && ret.deployer_data.name) {
 					sync_opts.deployer_data[ret.deployer_data.name] = ret.deployer_data;
 				}
-				if (!deployer_data._cached) {										// do not run sync w/cached deployer data
+				if (deployer_data && !deployer_data._cached) {						// do not run sync w/cached deployer data
 					batch_sync_deployer_attributes_with_couch(sync_opts);			// we don't wait on batch sync... todo re-evaluate
 				}
 				return cb(null, ret);

--- a/packages/athena/libs/deployer_lib.js
+++ b/packages/athena/libs/deployer_lib.js
@@ -1165,7 +1165,9 @@ module.exports = function (logger, ev, t) {
 					athena_docs: athena_data ? athena_data.components : null,		// pass athena docs on too, useful
 					deployer_data: deployer_data,
 				};
-				batch_sync_deployer_attributes_with_couch(ret);						// we don't wait on batch sync... todo re-evaluate
+				if (!deployer_data._cached) {										// do not run sync on w/cached deployer data
+					batch_sync_deployer_attributes_with_couch(ret);					// we don't wait on batch sync... todo re-evaluate
+				}
 				return cb(null, ret);
 			}
 		});
@@ -1193,6 +1195,7 @@ module.exports = function (logger, ev, t) {
 			const hit = t.proxy_cache.get(req._key);
 			if (hit && hit.resp && hit.key_src === req._key_src) {					// protect from hash collision
 				hit.resp._cached_timestamp = hit.cached_ts;
+				hit.resp._cached = true;
 				hit.resp._cache_expires_in = t.misc.friendly_ms(t.proxy_cache.getTtl(req._key) - Date.now());
 				logger.debug('[deployer lib] using cached value for the deployer api: get all components', hit.resp._cache_expires_in);
 				return cb(hit.error, hit.resp);
@@ -1325,7 +1328,9 @@ module.exports = function (logger, ev, t) {
 				if (ret.deployer_data && ret.deployer_data.name) {
 					sync_opts.deployer_data[ret.deployer_data.name] = ret.deployer_data;
 				}
-				batch_sync_deployer_attributes_with_couch(sync_opts);			// we don't wait on batch sync... todo re-evaluate
+				if (!deployer_data._cached) {										// do not run sync on w/cached deployer data
+					batch_sync_deployer_attributes_with_couch(sync_opts);			// we don't wait on batch sync... todo re-evaluate
+				}
 				return cb(null, ret);
 			}
 		});
@@ -1355,6 +1360,7 @@ module.exports = function (logger, ev, t) {
 			const hit = t.proxy_cache.get(req._key);
 			if (hit && hit.resp && hit.key_src === req._key_src) {		// protect from hash collision
 				hit.resp._cached_timestamp = hit.cached_ts;
+				hit.resp._cached = true;
 				hit.resp._cache_expires_in = t.misc.friendly_ms(t.proxy_cache.getTtl(req._key) - Date.now());
 				logger.debug('[deployer lib] using cached value for the deployer api: get component', hit.resp._cache_expires_in);
 				return cb(hit.error, hit.resp);

--- a/packages/athena/libs/deployer_lib.js
+++ b/packages/athena/libs/deployer_lib.js
@@ -1165,7 +1165,7 @@ module.exports = function (logger, ev, t) {
 					athena_docs: athena_data ? athena_data.components : null,		// pass athena docs on too, useful
 					deployer_data: deployer_data,
 				};
-				if (!deployer_data._cached) {										// do not run sync on w/cached deployer data
+				if (!deployer_data._cached) {										// do not run sync w/cached deployer data
 					batch_sync_deployer_attributes_with_couch(ret);					// we don't wait on batch sync... todo re-evaluate
 				}
 				return cb(null, ret);
@@ -1328,7 +1328,7 @@ module.exports = function (logger, ev, t) {
 				if (ret.deployer_data && ret.deployer_data.name) {
 					sync_opts.deployer_data[ret.deployer_data.name] = ret.deployer_data;
 				}
-				if (!deployer_data._cached) {										// do not run sync on w/cached deployer data
+				if (!deployer_data._cached) {										// do not run sync w/cached deployer data
 					batch_sync_deployer_attributes_with_couch(sync_opts);			// we don't wait on batch sync... todo re-evaluate
 				}
 				return cb(null, ret);
@@ -1999,6 +1999,7 @@ module.exports = function (logger, ev, t) {
 		if (SKIP_CACHE === false && ev.PROXY_CACHE_ENABLED === true) {				// check the cache first
 			const hit = t.proxy_cache.get(req._key);
 			if (hit && hit.resp && hit.key_src === req._key_src) {					// protect from hash collision
+				hit.resp._cached = true;
 				logger.debug('[deployer lib] using cached value for the deployer api: get fabric versions', hit.resp._cache_expires_in);
 				return cb(hit.error, hit.resp);
 			}


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
The cached deployer data cannot be used to synchronize the state of the component. It should be skipped, unless the real (up-to-date) data was obtained.

