### PR TITLE
allow zero length admin array for org

### DIFF
--- a/packages/apollo/src/components/MSPDefinitionModal/MSPDefinitionModal.js
+++ b/packages/apollo/src/components/MSPDefinitionModal/MSPDefinitionModal.js
@@ -218,7 +218,11 @@ export class MSPDefinitionModal extends Component {
 			disableSubmit: true,
 			error: null,
 		});
-		if (!this.props.msp_id || !this.props.msp_name || this.props.rootCerts.length === 0 || this.props.admins.length === 0) {
+
+		let notValidAdmin = (!this.props.fabric_node_ous?.enable && this.props.admins?.length === 0) ||
+							(this.props.fabric_node_ous?.enable && this.props.admins === undefined);
+
+		if (!this.props.msp_id || !this.props.msp_name || this.props.rootCerts.length === 0 || notValidAdmin) {
 			// required fields
 			this.props.updateState(SCOPE, {
 				error: {


### PR DESCRIPTION
Signed-off-by: Varad Ramamoorthy <varad@us.ibm.com>

#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description
Historically Fabric required admin certs for an organization... somewhere around 1.4 when Node OU was introduced, admin certs in the orgs were no longer required. Adjusting the code to accommodate that

https://github.com/hyperledger-labs/fabric-operations-console/issues/203

