### PR TITLE
rebuild safelist when validating create-peer api

### DIFF
--- a/packages/athena/libs/component_lib.js
+++ b/packages/athena/libs/component_lib.js
@@ -1036,7 +1036,7 @@ module.exports = function (logger, ev, t) {
 	}
 
 	//-------------------------------------------------------------
-	// Rebuild ips/domains on whitelist
+	// Rebuild ips/domains on whitelist aka safelist
 	//-------------------------------------------------------------
 	exports.rebuildWhiteList = (req, cb) => {
 		req._skip_cache = true;
@@ -1047,7 +1047,7 @@ module.exports = function (logger, ev, t) {
 			(join) => {
 				exports.get_all_components(req, (err, resp) => {
 					if (err) {
-						logger.warn('[comp lib] could not get component docs to rebuild white list', err);
+						logger.warn('[comp lib] could not get component docs to rebuild hostname safelist', err);
 					}
 					join(err, resp);
 				});
@@ -1057,7 +1057,7 @@ module.exports = function (logger, ev, t) {
 			(join) => {
 				t.signature_collection_lib.getSignatureCollectionsDocs(req, (err, resp) => {
 					if (err) {
-						logger.warn('[comp lib] could not get signature collections to rebuild white list', err);
+						logger.warn('[comp lib] could not get signature collections to rebuild hostname safelist', err);
 					}
 					join(null, resp);						// don't care if we can't get these
 				});
@@ -1065,7 +1065,7 @@ module.exports = function (logger, ev, t) {
 
 		], (a_err, results) => {
 			if (a_err) {
-				logger.error('[comp lib] cannot update white list, could not get components'); // error details already logged
+				logger.error('[comp lib] cannot update hostname safelist, could not get components'); // error details already logged
 				return cb(a_err);
 			} else {
 				const components_arr = results[0] ? results[0].components : [];
@@ -1110,24 +1110,29 @@ module.exports = function (logger, ev, t) {
 				}
 			}
 
-			// get the settings doc to edit it
 			const opts = {
 				db_name: ev.DB_SYSTEM,
 				_id: process.env.SETTINGS_DOC_ID
 			};
-			t.otcc.repeatWriteSafe(opts, (settings_doc) => {		// don't use wr_doc in callback, use "doc" passed into writeDoc
-				settings_doc.host_white_list = Object.keys(urls2add);
-				return { doc: settings_doc };						// doc has the right _rev
-			}, (err) => {
-				if (err) {
-					logger.error('error editing settings doc for white list 1', err);
-					return cb_built(err);
-				} else {
-					ev.update(null, () => {							// update settings to get the new white list setting
-						return cb_built(null);
-					});
-				}
-			});
+			const new_list = Object.keys(urls2add);
+
+			if (t.misc.is_equal_arr(ev.HOST_WHITE_LIST, new_list)) {	// if its the same, don't make a new write, would be pointless churn
+				logger.debug('[comp lib] hostname safelist has not changed, skipping write');
+				return cb_built(null, new_list);
+			} else {
+				ev.HOST_WHITE_LIST = new_list;
+				t.otcc.repeatWriteSafe(opts, (settings_doc) => {		// don't use wr_doc in callback, use "doc" passed into writeDoc
+					settings_doc.host_white_list = new_list;
+					return { doc: settings_doc };						// doc has the right _rev
+				}, (err) => {
+					if (err) {
+						logger.error('[comp lib] error editing settings doc for safelist 1', err);
+						return cb_built(err);
+					} else {
+						return cb_built(null, new_list);
+					}
+				});
+			}
 		}
 	};
 

--- a/packages/athena/libs/component_lib.js
+++ b/packages/athena/libs/component_lib.js
@@ -1127,7 +1127,7 @@ module.exports = function (logger, ev, t) {
 				}, (err) => {
 					if (err) {
 						logger.error('[comp lib] error editing settings doc for safelist 1', err);
-						return cb_built(err);
+						return cb_built(err, new_list);
 					} else {
 						return cb_built(null, new_list);
 					}

--- a/packages/athena/libs/component_lib.js
+++ b/packages/athena/libs/component_lib.js
@@ -1117,7 +1117,7 @@ module.exports = function (logger, ev, t) {
 			const new_list = Object.keys(urls2add);
 
 			if (t.misc.is_equal_arr(ev.HOST_WHITE_LIST, new_list)) {	// if its the same, don't make a new write, would be pointless churn
-				logger.debug('[comp lib] hostname safelist has not changed, skipping write');
+				logger.debug('[comp lib] hostname safelist has not changed, skipping a settings doc update');
 				return cb_built(null, new_list);
 			} else {
 				ev.HOST_WHITE_LIST = new_list;

--- a/packages/athena/libs/misc.js
+++ b/packages/athena/libs/misc.js
@@ -721,6 +721,25 @@ module.exports = function (logger, t) {
 	};
 
 	// ------------------------------------------
+	// compares if arrays have differences or not (when order does not matter)
+	// ------------------------------------------
+	exports.is_equal_arr = function (a, b) {
+		try {
+			a = JSON.parse(JSON.stringify(a));
+			b = JSON.parse(JSON.stringify(b));
+			a.sort();						// order does not matter for this function
+			b.sort();
+		} catch (e) { }
+
+		try {
+			return JSON.stringify(a) === JSON.stringify(b);
+		} catch (e) {
+			logger.error('[misc] error when comparing arr fields', e);
+			return false;
+		}
+	};
+
+	// ------------------------------------------
 	// compares if JSON has differences or not
 	// ------------------------------------------
 	exports.is_equal = function (a, b) {

--- a/packages/athena/libs/ot_misc.js
+++ b/packages/athena/libs/ot_misc.js
@@ -191,7 +191,7 @@ module.exports = function (logger, t) {
 				}
 			}
 		}
-		logger.warn('host to proxy does not match white list', encodeURI(host));
+		logger.warn('[ot_misc] this hostname was not found in safelist', encodeURI(host));
 		return false;
 	};
 

--- a/packages/athena/libs/ot_misc.js
+++ b/packages/athena/libs/ot_misc.js
@@ -182,7 +182,7 @@ module.exports = function (logger, t) {
 	//-------------------------------------------------------------
 	exports.validateUrl = (url, white_list_regex_array) => {
 		const host = t.misc.get_host(url);
-		if (host) {
+		if (host && Array.isArray(white_list_regex_array)) {
 			for (let i in white_list_regex_array) {
 				const regex = RegExp(white_list_regex_array[i]);
 				const match = regex.test(host);

--- a/packages/athena/libs/validation_lib.js
+++ b/packages/athena/libs/validation_lib.js
@@ -754,12 +754,14 @@ module.exports = (logger, ev, t, opts) => {
 
 		// check if the hostname is in our whitelist or not
 		if (body_spec['x-validate_known_hostname'] === true) {
-			if (!t.ot_misc.validateUrl(input, ev.HOST_WHITE_LIST)) {
-				const symbols = {
-					'$PROPERTY_NAME': path2field.join('.'),
-				};
-				errors.push({ key: 'unknown_enroll_host', symbols: symbols });
-			}
+			t.component_lib.rebuildWhiteList(req, (error, whitelist) => {						// get up to date whitelist
+				if (!t.ot_misc.validateUrl(input, whitelist)) {
+					const symbols = {
+						'$PROPERTY_NAME': path2field.join('.'),
+					};
+					errors.push({ key: 'unknown_enroll_host', symbols: symbols });
+				}
+			});
 		}
 
 		// check for incompatible fabric "version" upgrades

--- a/packages/athena/libs/validation_lib.js
+++ b/packages/athena/libs/validation_lib.js
@@ -754,14 +754,12 @@ module.exports = (logger, ev, t, opts) => {
 
 		// check if the hostname is in our whitelist or not
 		if (body_spec['x-validate_known_hostname'] === true) {
-			t.component_lib.rebuildWhiteList(req, (error, whitelist) => {						// get up to date whitelist
-				if (!t.ot_misc.validateUrl(input, whitelist)) {
-					const symbols = {
-						'$PROPERTY_NAME': path2field.join('.'),
-					};
-					errors.push({ key: 'unknown_enroll_host', symbols: symbols });
-				}
-			});
+			if (!t.ot_misc.validateUrl(input, req._whitelist || ev.HOST_WHITE_LIST)) {
+				const symbols = {
+					'$PROPERTY_NAME': path2field.join('.'),
+				};
+				errors.push({ key: 'unknown_enroll_host', symbols: symbols });
+			}
 		}
 
 		// check for incompatible fabric "version" upgrades

--- a/packages/athena/test/test-suites/lib/misc.test.js
+++ b/packages/athena/test/test-suites/lib/misc.test.js
@@ -2207,6 +2207,62 @@ describe('Misc', () => {
 			]
 		},
 
+		// is_equal_arr
+		{
+			suiteDescribe: 'is_equal_arr',
+			mainDescribe: 'Run is_equal_arr',
+			testData: [
+				{
+					arrayOfInfoToTest: [
+						{
+							itStatement: 'should detect arrs as the same - test_id=nfnmrn',
+							expectBlock: (done) => {
+								let arr1;
+								let arr2;
+								arr1 = [1, 2, 3];
+								arr2 = [1, 2, 3];
+								expect(misc.is_equal_arr(arr1, arr2)).to.equal(true);
+
+								arr1 = [1, 2, 3, 4];
+								arr2 = [4, 3, 2, 1];
+								expect(misc.is_equal_arr(arr1, arr2)).to.equal(true);
+
+								arr1 = ['1', '1', '2', '3'];
+								arr2 = ['3', '1', '2', '1'];
+								expect(misc.is_equal_arr(arr1, arr2)).to.equal(true);
+
+								arr1 = ['1', 1, false, null];
+								arr2 = ['1', 1, null, false];
+								expect(misc.is_equal_arr(arr1, arr2)).to.equal(true);
+								done();
+							}
+						},
+						{
+							itStatement: 'should detect arrs as different - test_id=rhasjs',
+							expectBlock: (done) => {
+								let arr1;
+								let arr2;
+								arr1 = [1, 2, 3, 4];
+								arr2 = [4, 3, 2, 1, 1];
+								expect(misc.is_equal_arr(arr1, arr2)).to.equal(false);
+
+								arr1 = ['1', '1', '2', '3'];
+								arr2 = ['3', '1', '2'];
+								expect(misc.is_equal_arr(arr1, arr2)).to.equal(false);
+
+								arr1 = ['1', 1, false, null];
+								arr2 = [];
+								expect(misc.is_equal_arr(arr1, arr2)).to.equal(false);
+
+								expect(misc.is_equal_arr(arr1, null)).to.equal(false);
+								done();
+							}
+						}
+					]
+				}
+			]
+		},
+
 		// conform_bytes
 		{
 			suiteDescribe: 'conform_bytes',

--- a/packages/athena/test/test-suites/routes/deployer_apis.test.js
+++ b/packages/athena/test/test-suites/routes/deployer_apis.test.js
@@ -89,6 +89,10 @@ describe('Deployer APIs', () => {
 			return next();
 		};
 
+		tools.component_lib.rebuildWhiteList = (req, cb) => {
+			return cb();
+		};
+
 		deployer_lib = tools.deployer;
 		tools.stubs.record_deployer_operation = sinon.stub(deployer_lib, 'record_deployer_operation').callsArgWith(4, null, { prop: 'something here' });
 		tools.stubs.send_actions = sinon.stub(deployer_lib, 'send_actions').callsArgWith(1, null);


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
When creating a component the hostname safelist will be recalculated before API validation. 

This will fix the problem when a user creates a peer and the hostname of the CA for the peer's enrollment is not known to all instances of the console.

