### PR TITLE
add support for stitch to decode utf8 characters

### DIFF
--- a/packages/stitch/src/libs/misc.ts
+++ b/packages/stitch/src/libs/misc.ts
@@ -26,7 +26,7 @@ import { scGetHashAsHex } from './subtle_crypto';
 // exports
 export { logger, getLogger, pp, load_pb, __pb_root };
 export { uint8ArrayToStr, utf8StrToUint8Array, arrToUint8Array, uint8ArrayToHexStr, hexStrToUint8Array, generate_tx_id, base64toHexStr, url_join };
-export { base64ToUint8Array, sortObjectOut, uint8ArrayToBase64, isUint8Array, underscores_2_camelCase, friendly_ms, sort_keys, camelCase_2_underscores };
+export { base64ToUint8Array, base64ToUtf8, sortObjectOut, uint8ArrayToBase64, isUint8Array, underscores_2_camelCase, friendly_ms, sort_keys, camelCase_2_underscores };
 
 // ------------------------------------------
 // Load the protobuf json bundle - this is used to encode/decode protos (used by the "protobuf.js" lib)
@@ -163,7 +163,7 @@ function arrToUint8Array(arr: any) {		// dsh don't use this unless you cannot ca
 }
 
 // --------------------------------------------------------------------------------
-// Convert Uint8Array to a string - note this only works on strings that can be represented with utf 8
+// Convert Uint8Array to a string - note this only works on strings that can be represented with ascii
 // --------------------------------------------------------------------------------
 function uint8ArrayToStr(arr: Uint8Array) {
 	let ret = '';
@@ -171,6 +171,18 @@ function uint8ArrayToStr(arr: Uint8Array) {
 		ret += String.fromCharCode(arr[pos] & 255);
 	}
 	return ret;
+}
+
+// --------------------------------------------------------------------------------
+// Convert Base64 string to a utf8 string (utf8/unicode support)
+// --------------------------------------------------------------------------------
+function base64ToUtf8(str: string) {
+	if (typeof str === 'string') {
+		return decodeURIComponent(Array.prototype.map.call(atob(str), function (c: string) {
+			return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);		// create a URI encoded character from each byte
+		}).join(''));
+	}
+	return '';
 }
 
 // --------------------------------------------------------------------------------

--- a/packages/stitch/src/libs/proto_handlers/block_pb_lib.ts
+++ b/packages/stitch/src/libs/proto_handlers/block_pb_lib.ts
@@ -86,7 +86,7 @@ const massDecodeMap = <any>{	// this is only possible with maps (aka dictionarie
 };
 
 // Libs built by us
-import { logger, uint8ArrayToBase64, base64ToUint8Array, __pb_root, sort_keys } from '../misc';
+import { logger, uint8ArrayToBase64, base64ToUint8Array, base64ToUtf8, __pb_root, sort_keys } from '../misc';
 import { ChaincodeLib } from './chaincode_pb_lib';
 
 // exports
@@ -559,13 +559,13 @@ function decode_payload_data(b_data: any, type: number) {
 	// types are defined in common.proto HeaderType (0 - 7)
 	/*
 	MESSAGE = 0;                   // Used for messages which are signed but opaque
-    CONFIG = 1;                    // Used for messages which express the channel config
-    CONFIG_UPDATE = 2;             // Used for transactions which update the channel config
-    ENDORSER_TRANSACTION = 3;      // Used by the SDK to submit endorser based transactions
-    ORDERER_TRANSACTION = 4;       // Used internally by the orderer for management
-    DELIVER_SEEK_INFO = 5;         // Used as the type for Envelope messages submitted to instruct the Deliver API to seek
-    CHAINCODE_PACKAGE = 6;         // Used for packaging chaincode artifacts for install
-    PEER_RESOURCE_UPDATE = 7;      // Used for encoding updates to the peer resource configuration
+	CONFIG = 1;                    // Used for messages which express the channel config
+	CONFIG_UPDATE = 2;             // Used for transactions which update the channel config
+	ENDORSER_TRANSACTION = 3;      // Used by the SDK to submit endorser based transactions
+	ORDERER_TRANSACTION = 4;       // Used internally by the orderer for management
+	DELIVER_SEEK_INFO = 5;         // Used as the type for Envelope messages submitted to instruct the Deliver API to seek
+	CHAINCODE_PACKAGE = 6;         // Used for packaging chaincode artifacts for install
+	PEER_RESOURCE_UPDATE = 7;      // Used for encoding updates to the peer resource configuration
 	*/
 	if (type === 1) {						// config envelope
 		const p_config_envelope = Configtx_ConfigEnvelope.deserializeBinary(<Uint8Array>b_data);
@@ -681,7 +681,7 @@ function decode_payload_data(b_data: any, type: number) {
 					for (let z in kv_rwset.writesList) {
 						if (kv_rwset.writesList[z].value) {
 							try {
-								kv_rwset.writesList[z].value = atob(kv_rwset.writesList[z].value);	// decode "value", might break so don't kill yourself trying
+								kv_rwset.writesList[z].value = base64ToUtf8(kv_rwset.writesList[z].value);	// decode "value", might break so don't kill yourself trying
 							} catch (e) {
 							}
 						}

--- a/packages/stitch/src/stitch.ts
+++ b/packages/stitch/src/stitch.ts
@@ -47,7 +47,7 @@ import { ProposalResponse as ProposalResponse_ProposalResponse } from './protoc/
 // Libs built by us
 import { DEFAULT_ERROR_MSG } from './libs/validation';
 import { DER_signAndPackCsrPem, DER_parsePem } from './libs/asn1_lib';
-import { PolicyLib,  } from './libs/proto_handlers/policy_pb_lib';
+import { PolicyLib, } from './libs/proto_handlers/policy_pb_lib';
 import { ConfigTxLib } from './libs/proto_handlers/configtx_pb_lib';
 import { ProposalLib } from './libs/proto_handlers/proposal_pb_lib';
 import { conformPolicySyntax } from './libs/sig_policy_syntax_lib';
@@ -71,7 +71,7 @@ import { pem2jwks, importJwkEcdsaKey, pem2raw, exportJwkKey, exportHexKey, subtl
 import { scSignPemRaw, scGenEcdsaKeys, build_sig_collection_for_hash, scSignJwkRaw, validatePrivateKey, validatePublicKey } from './libs/crypto_misc';
 import { decode_chaincode_query_response, decode_chaincode_deployment_spec, decode_processed_transaction, } from './libs/proto_handlers/block_pb_lib';
 import { lc_installChaincode, lc_getInstalledChaincodeData, lc_getAllInstalledChaincodeData, lc_getInstalledChaincodePackage } from './libs/lifecycle';
-import { load_pb, uint8ArrayToStr, logger, getLogger, pp, sortObjectOut, uint8ArrayToHexStr, hexStrToUint8Array, utf8StrToUint8Array } from './libs/misc';
+import { load_pb, uint8ArrayToStr, logger, getLogger, pp, sortObjectOut, uint8ArrayToHexStr, hexStrToUint8Array, utf8StrToUint8Array, base64ToUtf8 } from './libs/misc';
 import { GrpcData, fmt_err, fmt_ok, find_alternative_status_message, is_error_code, Fmt, OrderFmt, OrderFmtBlock, fill_in_missing } from './libs/validation';
 import { LifecycleLib } from './libs/proto_handlers/lifecycle_pb_lib';
 import { getOSNChannels, getOSNChannel, joinOSNChannel, unjoinOSNChannel } from './libs/fabric_rest';
@@ -104,7 +104,7 @@ export {
 	pem2raw, exportJwkKey, exportHexKey, subtleVerifySignature, jwk2pem, exportPemKey, build_sig_collection_for_hash, scSignJwkRaw, scGenCSR,
 	test_encodeDecode_collection_config_packaged, load_pb, switchEncryption, encrypt, decrypt, DER_signAndPackCsrPem, DER_parsePem, getOrGenAesKey,
 	convertPolicy2PeerCliSyntax, policyIsMet, safer_hex_str, url_join, lifecycleLib, decode_chaincode_query_response, Query_ChannelQueryResponse,
-	Ledger_BlockchainInfo, policyLib
+	Ledger_BlockchainInfo, policyLib, base64ToUtf8
 };
 
 // proto handlers

--- a/packages/stitch/test/stitch.test.js
+++ b/packages/stitch/test/stitch.test.js
@@ -4158,6 +4158,28 @@ yJMfGXHykKD1d2F+B58=
 		});
 	});
 
+	describe('base64ToUtf8', () => {
+		testId = 0;
+
+		it(getId() + 'should return utf8 string - ascii', (done) => {
+			const b64str = 'aGVsbG8tdGhlcmUtYnVkZHkhQCMhJF4m';
+			expect(stitch.base64ToUtf8(b64str)).to.equal('hello-there-buddy!@#!$^&');
+			done();
+		});
+
+		it(getId() + 'should return utf8 string - utf8 - chinese', (done) => {
+			const b64str = '5ryi5a2X';
+			expect(stitch.base64ToUtf8(b64str)).to.equal('漢字');
+			done();
+		});
+
+		it(getId() + 'should return utf8 string - utf8 - emojii', (done) => {
+			const b64str = '8J+ZgvCfmIDwn5iD';
+			expect(stitch.base64ToUtf8(b64str)).to.equal('🙂😀😃');
+			done();
+		});
+	});
+
 	// ---------------------------------------------------------------------------------------------------------------------
 	// don't leave this test in.  comment it out and run it manually.
 	//describe('create a new channel', () => {


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement 

#### Description
Add support for decoding utf8 characters in fabric transaction outputs.  Specifically the read/write set from a transaction will now display correctly * **if** * utf8 characters were used.

fixes https://github.com/hyperledger-labs/fabric-operations-console/issues/198

