### PR TITLE
always get all msps on channel details page

### DIFF
--- a/packages/apollo/src/assets/i18n/en/messages.json
+++ b/packages/apollo/src/assets/i18n/en/messages.json
@@ -664,6 +664,7 @@
 	"remove_ca_confirm": "Please type the name of the Certificate Authority to confirm:",
 	"remove_consenter_system_channel_desc": "This action will remove the consenter ${name} from the ordering service system channel.",
 	"remove_consenter_application_channel_desc": "This action will remove the consenter ${name} from channel ${channelId}.",
+	"remove_consenter_confirm_channel": "Please type the name of the consenter to confirm:",
 	"remove_consenter_confirm": "Please type the URL of the consenter to confirm:",
 	"confirm_consenter_url": "Consenter URL",
 	"confirm_consenter_url_placeholder": "Enter the URL of the consenter to be removed",

--- a/packages/apollo/src/components/ChannelConsenterModal/ChannelConsenterModal.js
+++ b/packages/apollo/src/components/ChannelConsenterModal/ChannelConsenterModal.js
@@ -116,7 +116,7 @@ class ChannelConsenterModal extends React.Component {
 					</p>
 				</div>
 				<div>
-					<div className="ibp-remove-consenter-confirm">{translate('remove_consenter_confirm')}</div>
+					<div className="ibp-remove-consenter-confirm">{translate('remove_consenter_confirm_channel')}</div>
 					<Form
 						scope={SCOPE}
 						id={SCOPE + '-remove'}

--- a/packages/apollo/src/components/ChannelDetails/ChannelDetails.js
+++ b/packages/apollo/src/components/ChannelDetails/ChannelDetails.js
@@ -419,34 +419,35 @@ class ChannelDetails extends Component {
 							return isTLSCertMismatchFound;
 						})
 						.then(isTLSCertMismatchFound => {
-							if (isTLSCertMismatchFound) {
-								// Populate the orderer host url and orderer msps to send the update cert request to
-								MspRestApi.getAllMsps()
-									.then(async all_msps => {
-										let msps = [];
-										all_msps.forEach(msp => {
-											msps.push({ ...msp, display_name: msp.display_name + ' (' + msp.msp_id + ')' });
-										});
 
-										if (_.size(this.channel.orderers) > 0) {
-											const orderer_msp_ids = [];
-											this.channel.orderers.forEach(x =>
-												_.has(x, 'raft') ? x.raft.forEach(y => orderer_msp_ids.push(y.msp_id)) : orderer_msp_ids.push(x.msp_id)
-											);
-											msps = msps.filter(msp => orderer_msp_ids.includes(msp.msp_id));
-										}
-										this.props.updateState(SCOPE, {
-											ordererMSPs: msps,
-										});
-										const channelOrderer = this.orderers && this.orderers.length ? this.orderers[0] : null;
-										this.ordererHost = await OrdererRestApi.getOrdererURL(channelOrderer, this.consenters);
-										if (cb) cb();
-									})
-									.catch(error => {
-										Log.error(error);
-										this.props.updateState(SCOPE, { ordererMSPs: [] });
+							// Populate the orderer host url and orderer msps for the update cert flow && the remove consenter flow
+							MspRestApi.getAllMsps()
+								.then(async all_msps => {
+									let msps = [];
+									all_msps.forEach(msp => {
+										msps.push({ ...msp, display_name: msp.display_name + ' (' + msp.msp_id + ')' });
 									});
-							} else if (cb) cb();
+
+									if (_.size(this.channel.orderers) > 0) {
+										const orderer_msp_ids = [];
+										this.channel.orderers.forEach(x =>
+											_.has(x, 'raft') ? x.raft.forEach(y => orderer_msp_ids.push(y.msp_id)) : orderer_msp_ids.push(x.msp_id)
+										);
+										msps = msps.filter(msp => orderer_msp_ids.includes(msp.msp_id));
+									}
+									this.props.updateState(SCOPE, {
+										ordererMSPs: msps,
+									});
+
+									const channelOrderer = this.orderers && this.orderers.length ? this.orderers[0] : null;
+									this.ordererHost = await OrdererRestApi.getOrdererURL(channelOrderer, this.consenters);
+									if (cb) cb();
+								})
+								.catch(error => {
+									Log.error(error);
+									this.props.updateState(SCOPE, { ordererMSPs: [] });
+									if (cb) cb();
+								});
 						});
 				})
 				.catch(error => {
@@ -860,7 +861,7 @@ class ChannelDetails extends Component {
 				<p className="ibp-node-tile-msp">{node.msp_id}</p>
 				<ItemTileLabels
 					location={node.location}
-					// certificateWarning={node.certificateWarning}
+				// certificateWarning={node.certificateWarning}
 				/>
 				{this.getNodeStatus(node)}
 			</div>
@@ -1186,7 +1187,7 @@ class ChannelDetails extends Component {
 				msp_id: peer.msp_id,
 				client_cert_b64pem: peer.cert,
 				client_prv_key_b64pem: peer.private_key,
-			  }
+			}
 			: null;
 		return (
 			<PageContainer>

--- a/packages/apollo/src/components/ChannelModal/ChannelModal.js
+++ b/packages/apollo/src/components/ChannelModal/ChannelModal.js
@@ -1558,8 +1558,8 @@ class ChannelModal extends Component {
 			if (this.props.channelId && this.props.existingCapabilities) {
 
 				// When editing, allow capabilities that are higher than current capability
-				let currentChannelCapability = semver.coerce(this.props.existingCapabilities.channel.replace(/_/g, '.')).version;
-				let currentOrdererCapability = semver.coerce(this.props.existingCapabilities.orderer.replace(/_/g, '.')).version;
+				let currentChannelCapability = this.props.existingCapabilities.channel ? semver.coerce(this.props.existingCapabilities.channel.replace(/_/g, '.')).version : null;
+				let currentOrdererCapability = this.props.existingCapabilities.orderer ? semver.coerce(this.props.existingCapabilities.orderer.replace(/_/g, '.')).version : null;
 				let currentApplicationCapability = this.props.existingCapabilities.application
 					? semver.coerce(this.props.existingCapabilities.application.replace(/_/g, '.')).version
 					: null;


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix
    - cannot remove consenter from channel details page, msp drop down is empty.

#### Description

- from the channel details page the MSP data was only being retrieved if `isTLSCertMismatchFound` was true. This PR removes that condition and will always populate the MSP data. This data is required for the removed-consenter flow.
- also fixes the description text on the remove-consenter flow
