### PR TITLE
add support for stitch to decode utf8 characters - input

### DIFF
--- a/packages/stitch/src/libs/proto_handlers/block_pb_lib.ts
+++ b/packages/stitch/src/libs/proto_handlers/block_pb_lib.ts
@@ -726,7 +726,7 @@ function decode_payload_data(b_data: any, type: number) {
 			if (input && input.chaincodeSpec && input.chaincodeSpec.input) {			// base64 decode the input strings
 				for (let x in input.chaincodeSpec.input.argsList) {
 					try {
-						input.chaincodeSpec.input.argsList[x] = atob(<string>input.chaincodeSpec.input.argsList[x]);
+						input.chaincodeSpec.input.argsList[x] = base64ToUtf8(<string>input.chaincodeSpec.input.argsList[x]);
 					} catch (e) { }
 				}
 			}

--- a/packages/stitch/src/libs/proto_handlers/lifecycle_pb_lib.ts
+++ b/packages/stitch/src/libs/proto_handlers/lifecycle_pb_lib.ts
@@ -13,7 +13,7 @@
 */
 
 // Libs built by us
-import { __pb_root, logger, base64ToUint8Array, camelCase_2_underscores } from '../misc';
+import { __pb_root, logger, base64ToUint8Array, base64ToUtf8, camelCase_2_underscores } from '../misc';
 import { conformPolicySyntax } from '../sig_policy_syntax_lib';
 import { MixedPolicySyntax } from '../proto_handlers/collection_pb_lib';
 import { convertPolicy2PeerCliSyntax } from '../sig_policy_syntax_reverse_lib';
@@ -272,7 +272,7 @@ function decode_validationParameter(parameter: string) {
 	if (typeof parameter) {
 		let temp = '';
 		try {											// policy might be a simple string, or the fabric sig policy object syntax
-			temp = atob(parameter);						// base 64 decode, look for simple string
+			temp = base64ToUtf8(parameter);				// base 64 decode, look for simple string
 		} catch (e) { }
 
 		const pos = temp.indexOf('/');


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement 

#### Description
Add support for decoding utf8 characters in fabric transaction  * inputs *.  Similar to https://github.com/hyperledger-labs/fabric-operations-console/pull/210

fixes https://github.com/hyperledger-labs/fabric-operations-console/issues/198

