### PR TITLE
add option to create system channel-less orderers

### DIFF
--- a/packages/apollo/src/assets/i18n/en/messages.json
+++ b/packages/apollo/src/assets/i18n/en/messages.json
@@ -2272,7 +2272,7 @@
 	"remove_hsm": "Remove HSM",
 	"manage_hsm": "Manage HSM",
 	"systemless_config": "Without a System Channel",
-	"systemless_tooltip": "Select this option only when you want to create an orderer without a system channel. This requires Fabric v2.4 or higher.",
+	"systemless_tooltip": "Select this option when you want to create an orderer without a system channel. If selected this will restrict the orderer to Fabric v2.4 or higher.",
 	"hsm_config_short": "Hardware Security Module (HSM)",
 	"hsm_peer_desc": "You can use a Hardware Security Module (HSM) to generate and store the private keys used by your Fabric nodes. An HSM protects your private keys and handles cryptographic operations, which allows your peers to sign transactions without exposing your private keys. The node uses the PKCS #11 cryptographic standard to communicate with an HSM.",
 	"hsm_orderer_desc": "You can use a Hardware Security Module (HSM) to generate and store the private keys used by your Fabric nodes. An HSM protects your private keys and handles cryptographic operations, which allows your ordering nodes to endorse transactions without exposing your private keys. The node uses the PKCS #11 cryptographic standard to communicate with an HSM.",

--- a/packages/apollo/src/rest/OrdererRestApi.js
+++ b/packages/apollo/src/rest/OrdererRestApi.js
@@ -853,6 +853,9 @@ class OrdererRestApi {
 		if (data.zones && data.zones.length) {
 			raft.zone = data.zones;
 		}
+		if (data.systemless) {
+			raft.systemless = true;
+		}
 		if (data.saas_ca) {
 			raft.crypto = [];
 			raft.config_override = [];
@@ -926,6 +929,7 @@ class OrdererRestApi {
 			type: 'fabric-orderer',
 			orderer_type: 'raft',
 			msp_id: data.admin_msp.msp_id,
+			systemless: data.systemless ? true : false,
 			crypto: data.saas_ca
 				? [
 					{

--- a/packages/athena/json_docs/json_validation/ibp_openapi_v3.yaml
+++ b/packages/athena/json_docs/json_validation/ibp_openapi_v3.yaml
@@ -13776,6 +13776,10 @@ components:
               $ref: '#/components/schemas/StorageObject'
         system_channel_id:
           $ref: '#/components/schemas/system_channel_id'
+        systemless:
+          type: boolean
+          description: If true, the orderer will not have a system channel and channel partipation APIs must be used to create application channels. Requires Fabric v2.4+. Defaults `false`.
+          example: true
         zone:
           type: array
           minLength: 0

--- a/packages/athena/json_docs/json_validation/ibp_openapi_v3.yaml
+++ b/packages/athena/json_docs/json_validation/ibp_openapi_v3.yaml
@@ -13778,7 +13778,7 @@ components:
           $ref: '#/components/schemas/system_channel_id'
         systemless:
           type: boolean
-          description: If true, the orderer will not have a system channel and channel partipation APIs must be used to create application channels. Requires Fabric v2.4+. Defaults `false`.
+          description: If true, the orderer will not have a system channel and channel participation APIs must be used to create application channels. Requires Fabric v2.4+. Defaults `false`.
           example: true
         zone:
           type: array

--- a/packages/athena/libs/comp_formatting_lib.js
+++ b/packages/athena/libs/comp_formatting_lib.js
@@ -590,6 +590,9 @@ module.exports = function (logger, ev, t) {
 			if (Array.isArray(incoming_body.admin_certs)) {
 				ret.admincerts = incoming_body.admin_certs;
 			}
+			if (incoming_body.systemless) {
+				ret.channelless = true;
+			}
 
 			return JSON.parse(JSON.stringify(ret));												// deep copy to get rid of undefined fields
 		}


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- New feature

#### Description
- Added ability to create orderers w/o a system channel. it is selectable via a checkbox. requires deployer to be present and the feature flag `osnadmin_feats_enabled` to be true.
   - note if this is selected channel participation APIs must be used to create application channels

