### PR TITLE
remove system channel check with deleting node without system channel

### DIFF
--- a/packages/apollo/.secrets.baseline
+++ b/packages/apollo/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-03-30T23:14:23Z",
+  "generated_at": "2022-06-03T15:02:58Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -13488,7 +13488,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.48.dss",
+  "version": "0.13.1+ibm.50.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/packages/apollo/src/components/OrdererModal/OrdererModal.js
+++ b/packages/apollo/src/components/OrdererModal/OrdererModal.js
@@ -491,7 +491,7 @@ class OrdererModal extends React.Component {
 		// todo This portion of the OrdererRestApi hasn't been updated to use translated errors.  Isolate it from the removeOrderer flow for now
 		try {
 			// only take out the node from consenter set if this is deployed (not imported)
-			if (this.props.orderer && this.props.orderer.location === 'ibm_saas' && this.props.ordererModalType !== 'force_delete') {
+			if (this.props.orderer && this.props.orderer.location === 'ibm_saas' && this.props.ordererModalType !== 'force_delete' && this.props.systemChannel === true) {
 				await OrdererRestApi.removeAllNodesFromSystemChannel(this.props.orderer, this.props.configtxlator_url, feature_flags);
 			}
 		} catch (error) {
@@ -2459,6 +2459,8 @@ export default withRouter(
 			newProps['capabilitiesEnabled'] =
 				state['settings'] && state['settings']['feature_flags'] ? state['settings']['feature_flags']['capabilities_enabled'] : null;
 			newProps['capabilities'] = state['settings'] && state['settings']['capabilities'] ? state['settings']['capabilities'] : [];
+			newProps['channelList'] = state['ordererDetails']['channelList'];
+			newProps['systemChannel'] = state['ordererDetails']['systemChannel'];
 			newProps['configtxlator_url'] = state['settings']['configtxlator_url'];
 			newProps['feature_flags'] = _.get(state, 'settings.feature_flags');
 			return newProps;

--- a/packages/athena/.secrets.baseline
+++ b/packages/athena/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|apollo|stitch|test/docs|test/integration_test/integration_test_docs|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-03-30T23:14:23Z",
+  "generated_at": "2022-06-03T15:02:42Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -1051,7 +1051,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.48.dss",
+  "version": "0.13.1+ibm.50.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/packages/stitch/.secrets.baseline
+++ b/packages/stitch/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-03-30T23:14:23Z",
+  "generated_at": "2022-06-03T15:02:58Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -4652,7 +4652,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.48.dss",
+  "version": "0.13.1+ibm.50.dss",
   "word_list": {
     "file": null,
     "hash": null


### PR DESCRIPTION
Signed-off-by: Varad Ramamoorthy <varad@us.ibm.com>

#### Type of change

- Bug fix

#### Description
Currently when deleting an ordering node without system channel, we still check for system channel to remove the node from consenters. This step needs to be skipped when dealing with nodes that don't have system channel.

