### PR TITLE
Suppress 404/503

### DIFF
--- a/packages/apollo/src/components/OrdererDetails/ChannelParticipationUnjoinModal.js
+++ b/packages/apollo/src/components/OrdererDetails/ChannelParticipationUnjoinModal.js
@@ -45,9 +45,13 @@ class ChannelParticipationUnjoinModal extends Component {
 					});
 				})
 				.catch(error => {
-					this.props.updateState(SCOPE, {
-						error,
-					});
+					// ignore 404/503 since some of the nodes may not have system channel
+					const status = _.get(error, 'grpc_resp.status');
+					if (status !== 404 && status !== 503) {
+						this.props.updateState(SCOPE, {
+							error,
+						});
+					}
 				});
 			this.props.updateState(SCOPE, {
 				loading: false,


### PR DESCRIPTION
#### Type of change

- Bug fix
#### Description
Suppress 404/503 - the check for maintenance mode goes across all nodes in the cluster and some nodes may not have system channel (since they have been removed)
