### PR TITLE
remove hardcoded title text, use product label str

### DIFF
--- a/packages/apollo/public/index.html
+++ b/packages/apollo/public/index.html
@@ -17,7 +17,8 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-		<title>IBM Blockchain Platform</title>
+		<!-- LeftNav.js changes the title -->
+		<title>Fabric Operations Console</title>
 		<script type="text/javascript" src="/stitch-dependencies.min.js"></script>
 		<script type="text/javascript" src="/stitch-main-min.js"></script>
 	</head>

--- a/packages/apollo/src/components/LeftNav/LeftNav.js
+++ b/packages/apollo/src/components/LeftNav/LeftNav.js
@@ -87,8 +87,10 @@ class LeftNav extends Component {
 		}
 	}
 
+	// change <title> of the browser tab
 	async getPageTitle(path) {
-		let title = 'IBM Blockchain Platform';
+		const translate = this.props.translate;
+		let title = translate('product_label');
 		let pathArray = path.split('/');
 		let suffix = pathArray[1];
 		let idx = pathArray.indexOf('channel');

--- a/packages/athena/docs/db_backup_apis.md
+++ b/packages/athena/docs/db_backup_apis.md
@@ -5,7 +5,7 @@ Start a backup of all **OpTools** databases.
 This api will return before the backup is done.
 Use the get-backup-doc api to see the status of a backup.
 - **Method**: POST
-- **Route**: `/api/v[123]/backups` || `/api/v[123]/backups`
+- **Route**: `/api/v[123]/backups` || `/ak/api/v[123]/backups`
 - **Auth**: need `blockchain.optools.settings` action
 - **Body**: `n/a`
 - **Response**:
@@ -51,7 +51,7 @@ Use the webhook api to see the status of the restore.
 Note: normally each doc in the backup data appears only once, but if it does appear multiple times the last one in the array will be the winning doc.
 Also note - after a restore the component white list will be rebuilt.
 - **Method**: PUT
-- **Route**: `/api/v[123]/backups` || `/api/v[123]/backups`
+- **Route**: `/api/v[123]/backups` || `/ak/api/v[123]/backups`
 - **Auth**: need `blockchain.optools.settings` action
 - **Query Params**:
 	- `skip_system` - should be an array of doc ids that will NOT be restored to the system db. example: `skip_system=["00_settings_athena"]`
@@ -83,7 +83,7 @@ This api will return before the restore is done.
 Use the webhook api to see the status of the restore.
 Also note - after a restore the component white list will be rebuilt.
 - **Method**: PUT
-- **Route**: `/api/v[123]/backups/:backup_id` || `/api/v[123]/backups/:backup_id`
+- **Route**: `/api/v[123]/backups/:backup_id` || `/ak/api/v[123]/backups/:backup_id`
 - **Auth**: need `blockchain.optools.settings` action
 - **Query Params**:
 	- `skip_system` - should be an array of doc ids that will NOT be restored to the system db. example: `skip_system="['00_settings_athena']"`


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
The base text for the browser tab title was hard coded. This fixes that and uses the product string.

