### PR TITLE
add ability to append ordering node to systemless

### DIFF
--- a/packages/apollo/src/components/ChannelModal/ChannelModal.js
+++ b/packages/apollo/src/components/ChannelModal/ChannelModal.js
@@ -1433,7 +1433,7 @@ class ChannelModal extends Component {
 		const selectedOrderer = data ? data : this.props.selectedOrderer;
 		if (!_.has(selectedOrderer, 'id')) return;
 
-		OrdererRestApi.getOrdererDetails(selectedOrderer.id, true).then(orderer => {
+		OrdererRestApi.getClusterDetails(selectedOrderer.cluster_id, true).then(orderer => {
 			let getCertsFromDeployer = false;
 
 			if (orderer && orderer.raft) {

--- a/packages/apollo/src/components/OrdererModal/OrdererModal.js
+++ b/packages/apollo/src/components/OrdererModal/OrdererModal.js
@@ -109,9 +109,23 @@ class OrdererModal extends React.Component {
 			new_log_spec: null,
 		});
 		this.identities = null;
-		this.getCAWithUsers();
-		this.getChannelsWithNodes();
-		this.checkNodeStatus();
+		this.getCAWithUsers();			// dsh todo why is this always being called
+
+		try {
+			this.getChannelsWithNodes();
+		} catch (e) {
+			this.props.updateState(SCOPE, {
+				channel_loading: false,
+			});
+		}
+
+		try {
+			this.checkNodeStatus();
+		} catch (e) {
+			this.props.updateState(SCOPE, {
+				loading: false,
+			});
+		}
 	}
 
 	async getChannelsWithNodes() {
@@ -129,61 +143,78 @@ class OrdererModal extends React.Component {
 			ordererId: this.props.orderer.id,
 			configtxlator_url: this.props.configtxlator_url,
 		};
+
+		let allChannels = null;
 		this.props.updateState(SCOPE, {
 			channel_loading: true,
 		});
-		let allChannels = await OrdererRestApi.getAllChannelNamesFromOrderer(options);
-		this.props.updateState(SCOPE, {
-			channel_loading: false,
-		});
-		allChannels.forEach(async channel_id => {
-			let block_options = {
-				ordererId: options.ordererId,
-				channelId: channel_id,
-				configtxlator_url: options.configtxlator_url,
-			};
-			this.props.updateState(SCOPE, {
-				channel_loading: true,
-			});
-			try {
-				const block = await OrdererRestApi.getChannelConfigBlock(block_options);
-				const _block_binary2json = promisify(ChannelApi._block_binary2json);
-				const resp = await _block_binary2json(block, options.configtxlator_url);
-				let l_consenters = _.get(resp, 'data.data[0].payload.data.config.channel_group.groups.Orderer.values.ConsensusType.value.metadata.consenters', []);
-				let orderersInConsenter = [];
-				nodesToDelete.forEach(node => {
-					let ordererInConsenter = _.filter(l_consenters, consenter => {
-						return node.backend_addr === consenter.host + ':' + Number(consenter.port);
-					});
-					if (!_.isEmpty(ordererInConsenter)) orderersInConsenter.push(ordererInConsenter);
-				});
-				// if this is the only node in consenter, don't count the channel
-				if (orderersInConsenter.length > 0 && orderersInConsenter.length !== l_consenters.length) {
-					let channelsWithNode = [...this.props.channelsWithNode, channel_id];
-					channelsWithNode.sort((a, b) => {
-						return naturalSort(a, b);
-					});
-					this.props.updateState(SCOPE, {
-						channelsWithNode,
-					});
-				} else if (orderersInConsenter.length > 0 && orderersInConsenter.length === l_consenters.length) {
-					let safeChannelsWithNode = [...this.props.safeChannelsWithNode, channel_id];
-					safeChannelsWithNode.sort((a, b) => {
-						return naturalSort(a, b);
-					});
-					this.props.updateState(SCOPE, {
-						safeChannelsWithNode,
-					});
-				}
-			} catch (error) {
-				this.props.updateState(SCOPE, {
-					channel_loading: false,
-				});
-				Log.error(error);
-			}
+
+		try {
+			// dsh todo why are we getting channel names form system channel if there sys channel dne
+			allChannels = await OrdererRestApi.getAllChannelNamesFromOrderer(options);
+		} catch (e) {
+			Log.error('unable to load all channels from orderer', e);
+		}
+
+		if (!allChannels) {
 			this.props.updateState(SCOPE, {
 				channel_loading: false,
 			});
+		} else {
+			allChannels.forEach(async channel_id => {
+				let block_options = {
+					ordererId: options.ordererId,
+					channelId: channel_id,
+					configtxlator_url: options.configtxlator_url,
+				};
+				this.props.updateState(SCOPE, {
+					channel_loading: true,
+				});
+				try {
+					const block = await OrdererRestApi.getChannelConfigBlock(block_options);
+					const _block_binary2json = promisify(ChannelApi._block_binary2json);
+					const resp = await _block_binary2json(block, options.configtxlator_url);
+					let l_consenters = _.get(resp, 'data.data[0].payload.data.config.channel_group.groups.Orderer.values.ConsensusType.value.metadata.consenters', []);
+					let orderersInConsenter = [];
+					nodesToDelete.forEach(node => {
+						let ordererInConsenter = _.filter(l_consenters, consenter => {
+							return node.backend_addr === consenter.host + ':' + Number(consenter.port);
+						});
+						if (!_.isEmpty(ordererInConsenter)) orderersInConsenter.push(ordererInConsenter);
+					});
+					// if this is the only node in consenter, don't count the channel
+					if (orderersInConsenter.length > 0 && orderersInConsenter.length !== l_consenters.length) {
+						let channelsWithNode = [...this.props.channelsWithNode, channel_id];
+						channelsWithNode.sort((a, b) => {
+							return naturalSort(a, b);
+						});
+						this.props.updateState(SCOPE, {
+							channelsWithNode,
+						});
+					} else if (orderersInConsenter.length > 0 && orderersInConsenter.length === l_consenters.length) {
+						let safeChannelsWithNode = [...this.props.safeChannelsWithNode, channel_id];
+						safeChannelsWithNode.sort((a, b) => {
+							return naturalSort(a, b);
+						});
+						this.props.updateState(SCOPE, {
+							safeChannelsWithNode,
+						});
+					}
+				} catch (error) {
+					this.props.updateState(SCOPE, {
+						channel_loading: false,
+					});
+					Log.error(error);
+				}
+
+				this.props.updateState(SCOPE, {
+					channel_loading: false,
+				});
+			});
+		}
+
+		this.props.updateState(SCOPE, {
+			channel_loading: false,
 		});
 	}
 
@@ -211,7 +242,8 @@ class OrdererModal extends React.Component {
 			loading: true,
 		});
 		let components = {};
-		let orderer = await OrdererRestApi.getOrdererDetails(this.props.orderer.cluster_id);
+
+		let orderer = await OrdererRestApi.getClusterDetails(this.props.orderer.cluster_id);
 		if (_.has(orderer, 'raft')) {
 			orderer.raft.forEach(x => {
 				components[x.id] = {
@@ -228,20 +260,22 @@ class OrdererModal extends React.Component {
 			let notOkList = _.filter(statuses, status => status.status === 'not ok');
 			if (_.size(notOkList) > 0) {
 				const down_nodes = notOkList.map(node => {
-					const node_details = orderer.raft.find(component => component.operations_url + '/healthz' === node.status_url);
-					return node_details.display_name;
+					if (orderer && orderer.raft) {
+						const node_details = orderer.raft.find(component => component.operations_url + '/healthz' === node.status_url);
+						return node_details.display_name;
+					}
 				});
 				this.props.updateState(SCOPE, {
 					down_nodes,
-					loading: false,
 				});
 			}
 		} catch (e) {
 			Log.error(e);
-			this.props.updateState(SCOPE, {
-				loading: false,
-			});
 		}
+
+		this.props.updateState(SCOPE, {
+			loading: false,
+		});
 	}
 
 	getCAList() {
@@ -294,8 +328,6 @@ class OrdererModal extends React.Component {
 					});
 				}
 				this.props.updateState(SCOPE, {
-					enroll_id: users.length ? users[0].id : undefined,
-					enroll_secret: undefined,
 					users,
 					loadingUsers: false,
 				});
@@ -303,7 +335,6 @@ class OrdererModal extends React.Component {
 			.catch(error => {
 				Log.error(error);
 				this.props.updateState(SCOPE, {
-					enroll_id: undefined,
 					users: [],
 					loadingUsers: false,
 				});
@@ -747,6 +778,13 @@ class OrdererModal extends React.Component {
 						key={button.id}
 						className="ibp-ca-action bx--btn bx--btn--tertiary bx--btn--sm"
 						onClick={() => {
+							/*if (button) {
+								// dsh todo - move things out...
+								if (button.id === 'update_certs') {
+									this.getCAWithUsers();
+								}
+							}*/
+
 							if (button.onClick) {
 								button.onClick();
 							} else {

--- a/packages/apollo/src/rest/ChannelApi.js
+++ b/packages/apollo/src/rest/ChannelApi.js
@@ -1504,7 +1504,12 @@ class ChannelApi {
 					config_update_signatures: [signature],
 				};
 				try {
-					let orderers = await OrdererRestApi.getOrdererDetails(options.cluster_id || options.currentOrdererId || options.ordererId);
+					let orderers = null;
+					if (options.cluster_id) {
+						orderers = await OrdererRestApi.getClusterDetails(options.cluster_id);
+					} else {
+						orderers = await OrdererRestApi.getOrdererDetails(options.currentOrdererId || options.ordererId);
+					}
 					orderers = orderers.raft ? orderers.raft : [orderers];
 					const resp3 = await StitchApi.submitWithRetry(c_opts, orderers);
 					// send async event... don't wait

--- a/packages/athena/libs/deployer_lib.js
+++ b/packages/athena/libs/deployer_lib.js
@@ -117,7 +117,11 @@ module.exports = function (logger, ev, t) {
 						const athena_comp_type = (incoming_body && incoming_body.type) ? incoming_body.type.toLowerCase() : null;
 						if (athena_comp_type === ev.STR.ORDERER) {
 							build_body_opts.node_i = 0;
-							build_body_opts.consenter_proposal_fin = false;
+							if (incoming_body.systemless === true) {			// nodes w/o the system channel should not have this flag set
+								build_body_opts.consenter_proposal_fin = true;
+							} else {
+								build_body_opts.consenter_proposal_fin = false;
+							}
 						}
 						const component_req = {
 							path: req2athena.path,			// pass path so the response formatter knows what api version was called to pick the format
@@ -389,7 +393,7 @@ module.exports = function (logger, ev, t) {
 					fill_in_existing_raft_details(build_object_fields(fmt_body), (_, filled_body) => {
 						call_deployer(filled_body, route2use);
 					});
-				} else {															// all other components go here
+				} else {																// all other components go here
 					call_deployer(fmt_body, route2use);
 				}
 			}
@@ -423,10 +427,13 @@ module.exports = function (logger, ev, t) {
 			let url2use = '';
 			if (fmt_body.orderertype === ev.STR.RAFT) {									// raft orderer clusters use different routes than other components
 				if (!is_appending_raft) {												// creating new raft cluster
-					logger.debug('[deployer lib]', req._tx_id, 'rafting we be. orderer type:', fmt_body.orderertype, 'id:', fmt_body.dep_component_id);
+					logger.debug('[deployer lib]', req._tx_id, 'ordering-cluster creating we be. id:', fmt_body.dep_component_id);
 					url2use = '/api/v3/instance/' + parsed.iid + '/type/orderer/component';
-				} else {																// appending to an existing raft cluster
-					logger.debug('[deployer lib]', req._tx_id, 'raft appending we be. orderer type:', fmt_body.orderertype, 'id:', fmt_body.dep_component_id);
+				} else if (fmt_body.channelless || fmt_body.systemless) {				// appending to an existing raft cluster without system channel
+					logger.debug('[deployer lib]', req._tx_id, 'systemless ordering-cluster appending we be. id:', fmt_body.dep_component_id);
+					url2use = '/api/v3/instance/' + parsed.iid + '/precreate/type/orderer/component';
+				} else {																// appending to an existing raft cluster with system channel
+					logger.debug('[deployer lib]', req._tx_id, 'legacy ordering-cluster appending we be. id:', fmt_body.dep_component_id);
 					url2use = '/api/v3/instance/' + parsed.iid + '/precreate/type/orderer/component';
 				}
 				if (fmt_body.dep_component_id) {										// only add if found, id is optional
@@ -455,6 +462,10 @@ module.exports = function (logger, ev, t) {
 			};
 			logger.debug('[deployer lib]', req._tx_id, 'sending deployer api w/route:', opts.url);
 			send_dep_req(opts, (err, depRespBody) => {
+				/*depRespBody = {
+					location: 'ibm-saas'
+				};
+				const fmt_ret = {};*/
 				const { fmt_err, fmt_ret } = handle_dep_response(parsed, err, depRespBody);
 				if (fmt_err) {																// error is already logged
 					if (t.ot_misc.get_code(fmt_err) === 409) {								// don't call clean up on a 409 error code
@@ -1902,6 +1913,7 @@ module.exports = function (logger, ev, t) {
 
 		send_dep_req(options, (err, depRespBody) => {
 			let { fmt_err, fmt_ret } = handle_dep_response(parsed, err, depRespBody);
+			//fmt_err = null;
 			if (fmt_err && opts.FORCE === true) {
 				logger.debug('[deployer lib]', opts.debug_tx_id, 'deployer resp has error, but force is set. will force del component:', parsed.component_id);
 				fmt_err = null;												// if we are forcing del, we don't care about deployer errors

--- a/packages/athena/libs/deployer_lib.js
+++ b/packages/athena/libs/deployer_lib.js
@@ -462,10 +462,6 @@ module.exports = function (logger, ev, t) {
 			};
 			logger.debug('[deployer lib]', req._tx_id, 'sending deployer api w/route:', opts.url);
 			send_dep_req(opts, (err, depRespBody) => {
-				/*depRespBody = {
-					location: 'ibm-saas'
-				};
-				const fmt_ret = {};*/
 				const { fmt_err, fmt_ret } = handle_dep_response(parsed, err, depRespBody);
 				if (fmt_err) {																// error is already logged
 					if (t.ot_misc.get_code(fmt_err) === 409) {								// don't call clean up on a 409 error code
@@ -1913,7 +1909,6 @@ module.exports = function (logger, ev, t) {
 
 		send_dep_req(options, (err, depRespBody) => {
 			let { fmt_err, fmt_ret } = handle_dep_response(parsed, err, depRespBody);
-			//fmt_err = null;
 			if (fmt_err && opts.FORCE === true) {
 				logger.debug('[deployer lib]', opts.debug_tx_id, 'deployer resp has error, but force is set. will force del component:', parsed.component_id);
 				fmt_err = null;												// if we are forcing del, we don't care about deployer errors


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- New feature

#### Description
- Added the ability to append ordering nodes to an existing cluster that are * not * using a system channel.
- This also introduces some performance improvements by eliminating some redundant apis/spam

