### PR TITLE
fix get-channels logic if response is empty

### DIFF
--- a/packages/apollo/src/utils/helper.js
+++ b/packages/apollo/src/utils/helper.js
@@ -159,7 +159,7 @@ const Helper = {
 				type: node.type,
 				msp_id: node.msp_id,
 				systemless: node.systemless,
-				system_channel_id: node.systemless ? null : node.system_channel_id,
+				system_channel_id: node.systemless ? '' : node.system_channel_id,
 				msp: node.msp,
 				cluster_id: Helper.normalizeClusterId(node.cluster_id),
 				cluster_name: node.cluster_name,

--- a/packages/athena/libs/comp_formatting_lib.js
+++ b/packages/athena/libs/comp_formatting_lib.js
@@ -73,7 +73,7 @@ module.exports = function (logger, ev, t) {
 			doc.location = doc.location || '-';			// init field if dne
 			if (doc.type === ev.STR.ORDERER) {
 				doc.consenter_proposal_fin = (doc.consenter_proposal_fin === false) ? false : true;	// legacy docs should be set to `true`
-				doc.system_channel_id = doc.system_channel_id || ev.SYSTEM_CHANNEL_ID;
+				doc.system_channel_id = (typeof doc.system_channel_id === 'string') ? doc.system_channel_id : ev.SYSTEM_CHANNEL_ID;
 			}
 
 			if (t.ot_misc.detect_ak_route(req)) {

--- a/packages/athena/libs/component_lib.js
+++ b/packages/athena/libs/component_lib.js
@@ -140,7 +140,8 @@ module.exports = function (logger, ev, t) {
 				component_doc.tags.push(ev.STR.ORDERER);
 				component_doc.consenter_proposal_fin = (component_doc.consenter_proposal_fin === false) ? false : true;	// legacy docs should be `true`
 				if (component_doc.system_channel_id) {		// if it exists, copy, if not skip or else will trigger needless multi edit for raft
-					component_doc.system_channel_id = component_doc.system_channel_id || ev.SYSTEM_CHANNEL_ID;
+					component_doc.system_channel_id = (typeof component_doc.system_channel_id === 'string') ?
+						component_doc.system_channel_id : ev.SYSTEM_CHANNEL_ID;
 				}
 			} else if (component_doc.type === ev.STR.MSP || component_doc.type === ev.STR.MSP_EXTERNAL) {
 				component_doc.tags.push(component_doc.type);

--- a/packages/athena/libs/validation_lib.js
+++ b/packages/athena/libs/validation_lib.js
@@ -568,7 +568,7 @@ module.exports = (logger, ev, t, opts) => {
 				}
 			}
 			if (body_spec['maxLength'] !== undefined) {
-				if (input.length > body_spec['maxLength']) {
+				if (input && input.length > body_spec['maxLength']) {
 					const symbols = {
 						'$PROPERTY_NAME': path2field.join('.'),
 						'$MAX': body_spec['maxLength'],

--- a/packages/stitch/src/libs/fabric_rest.ts
+++ b/packages/stitch/src/libs/fabric_rest.ts
@@ -194,8 +194,12 @@ function getOSNChannels(opts: ExtOsn, cb: Function) {
 	};
 	proxy_fetch_get_json(fetch_options).then(response => {
 		called_cb = true;
+		if (response && response.channels === null) {	// this can be null for some reason, make it an empty array
+			response.channels = [];
+		}
+
 		if (!response || !response.channels) {
-			return cb(fmt_err(fetch_options, response, 'Failed to get channels'), response);
+			return cb(fmt_err(fetch_options, response, 'Failed to get channels (the response was valid but empty)'), response);
 		} else {
 			return cb(null, fmt_ok(fetch_options, response));
 		}


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description

- fixes the response to get-osn-channels when there are 0 channels. makes it an empty array instead of null.
- fixes `system_channel_id` filed being set to null, should be empty string when there is no system channel

