### PR TITLE
Fix unjoin system channel

### DIFF
--- a/packages/apollo/src/components/OrdererDetails/ChannelParticipationDetails.js
+++ b/packages/apollo/src/components/OrdererDetails/ChannelParticipationDetails.js
@@ -127,13 +127,15 @@ class ChannelParticipationDetails extends Component {
 						title={translate('unjoin_channel_title')}
 					/>
 				</button>
-				<button className="ibp-orderer-channel-join"
-					onClick={() => this.joinChannel(channel)}
-				>
-					<SVGs type="plus"
-						title={translate('join_osn_title')}
-					/>
-				</button>
+				{this.props.isSystemLess && (
+					<button className="ibp-orderer-channel-join"
+						onClick={() => this.joinChannel(channel)}
+					>
+						<SVGs type="plus"
+							title={translate('join_osn_title')}
+						/>
+					</button>
+				)}
 			</div>
 		);
 	}
@@ -165,13 +167,16 @@ class ChannelParticipationDetails extends Component {
 							},
 						}}
 						addItems={
-							[{
-								id: 'join_channel',
-								text: 'join_channel',
-								fn: () => {
-									this.joinChannel(null);
-								}
-							}]
+							this.props.isSystemLess ?
+								[{
+									id: 'join_channel',
+									text: 'join_channel',
+									fn: () => {
+										this.joinChannel(null);
+									}
+								}]
+
+								: []
 						}
 						widerTiles
 					/>)

--- a/packages/apollo/src/components/OrdererDetails/OrdererDetails.js
+++ b/packages/apollo/src/components/OrdererDetails/OrdererDetails.js
@@ -1453,13 +1453,14 @@ class OrdererDetails extends Component {
 															/>
 														</div>
 													}
-													{this.isSystemLess(this.props.details) && this.props.orderer_tls_identity &&
+													{this.channelParticipationEnabled(this.props.details) && this.props.orderer_tls_identity &&
 														<ChannelParticipationDetails
 															selectedNode={this.props.selectedNode}
 															channelList={this.props.channelList}
 															details={this.props.details}
 															unJoinComplete={this.getCPChannelList}
 															loading={this.props.loading}
+															isSystemLess={this.isSystemLess(this.props.details)}
 														/>
 													}
 													{!this.props.loading && !hasAssociatedIdentities && (

--- a/packages/apollo/src/components/OrdererModal/OrdererModal.js
+++ b/packages/apollo/src/components/OrdererModal/OrdererModal.js
@@ -609,7 +609,8 @@ class OrdererModal extends React.Component {
 		// todo This portion of the OrdererRestApi hasn't been updated to use translated errors.  Isolate it from the removeOrderer flow for now
 		try {
 			// only take out the node from consenter set if this is deployed (not imported)
-			if (this.props.orderer && this.props.orderer.location === 'ibm_saas' && this.props.ordererModalType !== 'force_delete' && this.props.systemChannel === true) {
+			// only take out these nodes if we are using a system channel, if systemless skip this part
+			if (this.props.orderer && this.props.orderer.location === 'ibm_saas' && this.props.ordererModalType !== 'force_delete' && this.props.systemChannel) {
 				await OrdererRestApi.removeAllNodesFromSystemChannel(this.props.orderer, this.props.configtxlator_url, feature_flags);
 			}
 		} catch (error) {
@@ -1321,7 +1322,7 @@ class OrdererModal extends React.Component {
 					</>
 				)}
 
-				{!this.props.systemChannel && this.props.channelsWithNode && this.props.channelsWithNode.length > 0 && (<Checkbox
+				{this.props.channelsWithNode && this.props.channelsWithNode.length > 0 && (<Checkbox
 					id="ignore-del-id"
 					labelText={translate('ignore_del_warning')}
 					onChange={() => {

--- a/packages/apollo/src/rest/ChannelParticipationApi.js
+++ b/packages/apollo/src/rest/ChannelParticipationApi.js
@@ -250,7 +250,7 @@ export class ChannelParticipationApi {
 			// use the last channel response data and the last osn to get the system channel details
 			if (last_ch_list_resp && last_ch_list_resp.systemChannel) {
 				const sys_name = last_ch_list_resp.systemChannel.name;
-				ret.systemChannel = await ChannelParticipationApi.map1Channel(identities, last_osn, sys_name);
+				ret.systemChannel = await ChannelParticipationApi.map1Channel(identities, [last_osn], sys_name);
 			}
 
 			return at_least_one_resp ? ret : null;


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
- the unjoin button from the system channel was not being shown, it now shows
- the ignore delete warnings was not be shown on orderers that used a system channel, it now shows on all orderers

