### PR TITLE
404 when joining channel

### DIFF
--- a/packages/apollo/src/components/JoinOSNChannelModal/JoinOSNChannelModal.js
+++ b/packages/apollo/src/components/JoinOSNChannelModal/JoinOSNChannelModal.js
@@ -126,7 +126,8 @@ class JoinOSNChannelModal extends React.Component {
 		let osn_to_use = this.props.selected_osn;							// default to the one selected in the drop down
 		if (this.props.joinChannelDetails && this.props.joinChannelDetails.nodes) {
 			for (let i in this.props.joinChannelDetails.nodes) {
-				if (this.props.joinChannelDetails.nodes[i]._channel_resp) {
+				if (this.props.joinChannelDetails.nodes[i]._channel_resp &&
+					this.props.joinChannelDetails.nodes[i]._channel_resp.consensusRelation === 'consenter') {
 					osn_to_use = this.props.joinChannelDetails.nodes[i];	// use the first node that knows this channel if available
 					break;
 				}


### PR DESCRIPTION
Signed-off-by: Varad Ramamoorthy <varad@us.ibm.com>

#### Type of change
- Bug fix

#### Description
when joining channel from an orderer cluster, if there are two nodes (one consenter and one follower) and if the follower happens to be the first one, there is a 404. Try getting the channel config block from consenter.