### PR TITLE
Filter orderer msps

### DIFF
--- a/packages/apollo/src/components/ChannelModal/ChannelModal.js
+++ b/packages/apollo/src/components/ChannelModal/ChannelModal.js
@@ -180,6 +180,7 @@ class ChannelModal extends Component {
 			loading: false,
 			submitting: false,
 			identities: null,
+			channelId: '',
 			orgs: [],
 			ordering_orgs: [],
 			original_orgs: [],
@@ -1030,7 +1031,7 @@ class ChannelModal extends Component {
 						: () => this.showStep('organization_creating_channel', group_prerequisites, step_org_signature);
 				next = () => {
 					if (isComplete) {
-						use_osnadmin
+						(use_osnadmin && !this.props.isChannelUpdate)
 							? this.showStep('osn_join_channel', group_review, osnadmin_join_channel)
 							: (this.props.isChannelUpdate ? this.updateChannel() : this.createChannel());
 					}

--- a/packages/apollo/src/components/ChannelModal/Wizard/Admins/Admins.js
+++ b/packages/apollo/src/components/ChannelModal/Wizard/Admins/Admins.js
@@ -29,7 +29,9 @@ import TranslateLink from '../../../TranslateLink/TranslateLink';
 
 const SCOPE = 'channelModal';
 
-// this panel allow selecting the **order orgs** for a channel
+// This is step "orderer_admin_set"
+//
+// this panel allow selecting the **orderer orgs** for a channel
 class Admins extends Component {
 	onAddAdmin = option => {
 		const orderer_orgs = _.isEmpty(this.props.orderer_orgs) ? [this.props.selectedAdmin] : [...this.props.orderer_orgs, this.props.selectedAdmin];


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
- fix orderer msp drop down options, removes msps that do not have a known orderer
- fixes update channel flow when system channel less orderer is used, prevents genesis block creation step from appearing

