### PR TITLE
use "bulk_add_components" for a systemless append

### DIFF
--- a/packages/athena/libs/ot_misc.js
+++ b/packages/athena/libs/ot_misc.js
@@ -1077,6 +1077,13 @@ module.exports = function (logger, t) {
 		}
 	};
 
+	// -----------------------------------------------------------------
+	// detect if body indicates an orderer without a system channel
+	// -----------------------------------------------------------------
+	exports.is_systemless_req = function (body) {
+		return (body.channelless === true || body.systemless === true);
+	};
+
 	//--------------------------------------------------
 	// wait for the fabric component to start
 	//--------------------------------------------------

--- a/packages/athena/libs/ot_misc.js
+++ b/packages/athena/libs/ot_misc.js
@@ -1081,7 +1081,11 @@ module.exports = function (logger, t) {
 	// detect if body indicates an orderer without a system channel
 	// -----------------------------------------------------------------
 	exports.is_systemless_req = function (body) {
-		return (body.channelless === true || body.systemless === true);
+		if (body) {
+			return (body.channelless === true || body.systemless === true);
+		} else {
+			return false;
+		}
 	};
 
 	//--------------------------------------------------


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
The systemless orderer append flow should use the `bulk_add_components` logic when onboarding and parsing deployer's create-orderer response. This is b/c deployer responds with an array of components and not an object for this route.

