### PR TITLE
fix the orderer/cluster select options in join wiz

### DIFF
--- a/packages/apollo/src/components/JoinOSNChannelModal/JoinOSNChannelModal.js
+++ b/packages/apollo/src/components/JoinOSNChannelModal/JoinOSNChannelModal.js
@@ -43,7 +43,7 @@ const url = require('url');
 class JoinOSNChannelModal extends React.Component {
 	async componentDidMount() {
 
-		// [Flow 1] - joining via the pending channel tile, is a new channel
+		// [Flows 1 & 4] - joining via the pending channel tile OR came from the create-channel wizard
 		if (this.props.selectedConfigBlockDoc) {
 			this.props.updateState(SCOPE, {
 				orderers: null,									// setting null here skips the first step
@@ -54,7 +54,7 @@ class JoinOSNChannelModal extends React.Component {
 			await this.setupForJoinViaPendingTile();
 		}
 
-		// [Flow 2] - joining via the join-channel button, the channel is not yet selected, show step to select a node and channel name
+		// [Flow 2] - joining via the join-channel blue button, the channel is not yet selected, show step to select a node and channel name
 		else if (!this.props.joinChannelDetails) {
 			// if we need to get orderers....
 			const oss = await OrdererRestApi.getOrderers(true);
@@ -75,7 +75,6 @@ class JoinOSNChannelModal extends React.Component {
 				disableSubmit: true,
 				submitting: false,								// submitting controls the wizard spinner after submit is clicked
 				configtxlator_url: this.props.configtxlator_url,
-				drill_down_flow: false,							// true if user clicked on specific cluster before coming to this panel
 				block_error: '',
 				show_channels_nav_link: false,
 			});
@@ -187,7 +186,7 @@ class JoinOSNChannelModal extends React.Component {
 		}
 	}
 
-	// get all known orderers and filter them to down to ones that can be a consenter
+	// get all known orderers and filter them to down to ones that *could* be a consenter (we just need the bare minimal fields, tls cert, hostname, & port)
 	async getAllOrderers() {
 		let orderers = null;
 		let possible_consenters = [];
@@ -268,12 +267,10 @@ class JoinOSNChannelModal extends React.Component {
 	countSelectedOrderers(useMap) {
 		let updateCount = 0;
 		for (let id in useMap) {
-			if (useMap[id].selected === true) {
-				for (let i in useMap[id].nodes) {
-					// don't count nodes that are already joined
-					if (useMap[id].nodes[i]._selected && useMap[id].nodes[i]._status !== constants.OSN_JOIN_SUCCESS) {
-						updateCount++;
-					}
+			for (let i in useMap[id].nodes) {
+				// don't count nodes that are already joined
+				if (useMap[id].nodes[i]._selected && useMap[id].nodes[i]._status !== constants.OSN_JOIN_SUCCESS) {
+					updateCount++;
 				}
 			}
 		}
@@ -354,35 +351,26 @@ class JoinOSNChannelModal extends React.Component {
 				consenter.name = node_data.name;
 				consenter._consenter = true;
 				consenter.osnadmin_url = node_data.osnadmin_url;
-
-				// get tls identity for node
-				const identity4tls = await ChannelParticipationApi.findMatchingIdentity({
-					identities: all_identities,
-					root_certs_b64pems: _.get(node_data, 'msp.tlsca.root_certs')
-				});
+				consenter._msp_id = node_data.msp_id;
 
 				const cluster_id = node_data._cluster_id;
 				if (!ret[cluster_id]) {
-					ret[cluster_id] = {
-						nodes: [],					// populated later
-						msp_id: node_data.msp_id,
-						cluster_name: node_data._cluster_name,
-						cluster_id: node_data._cluster_id,
-
-						// the identity we think they should use
-						tls_identity: identity4tls,
-
-						// if this cluster of orderer nodes is selected to join the channel - defaults true
-						selected: true,
-
-						// the root certs for the MSP that controls this cluster, used later in the join-channel api
-						tls_root_certs: (msp_data && msp_data[node_data.msp_id]) ? msp_data[node_data.msp_id].tls_root_certs : [],
-					};
-
-					// if the first node we itered on didn't find a tls identity for some reason this could still be null, replace it now
-					if (!ret[cluster_id].tls_identity) {
-						ret[cluster_id].tls_identity = identity4tls;
+					if (node_data && node_data.msp_id && node_data.osnadmin_url) {
+						ret[cluster_id] = await init_cluster(node_data, true);
 					}
+				}
+
+
+				// if the first node we itered on didn't find a tls identity for some reason this could still be null, replace it now
+				if (ret[cluster_id] && !ret[cluster_id].tls_identity) {
+
+					// get tls identity for node
+					const identity4tls = await ChannelParticipationApi.findMatchingIdentity({
+						identities: all_identities,
+						root_certs_b64pems: _.get(node_data, 'msp.tlsca.root_certs')
+					});
+
+					ret[cluster_id].tls_identity = identity4tls;
 				}
 
 				// orderer is not in map yet (this shouldn't be possible for the consenters array, but just in case)
@@ -398,10 +386,27 @@ class JoinOSNChannelModal extends React.Component {
 		// add nodes we are missing (these will be possible followers)
 		for (let i in all_orderers) {
 			const cluster_id = all_orderers[i]._cluster_id;
-			if (ret[cluster_id]) {											// only add nodes for cluster that was selected
-				if (!osn_already_exist(cluster_id, all_orderers[i]._id)) {	// orderer is not in map yet
-					if (all_orderers[i].osnadmin_url) {						// osn-join flow needs the osnadmin_url field
-						const node = all_orderers[i];
+			const msp_id = all_orderers[i].msp_id;
+			const node = all_orderers[i];
+
+			// if user has *not* entered via drill down then add nodes from all known clusters (init cluster if needed)
+			if (!ret[cluster_id] && !this.props.drill_down_flow) {
+				if (node && node.msp_id && node.osnadmin_url) {
+					ret[cluster_id] = await init_cluster(node, false);
+				}
+			}
+
+			// if ths cluster id dne, but this msp matches one that is a consenter, init this cluster and add its nodes
+			if (!ret[cluster_id] && msp_is_consenter(msp_id, consentersInConfigBlock)) {
+				if (node && node.msp_id && node.osnadmin_url) {
+					ret[cluster_id] = await init_cluster(node, true);
+				}
+			}
+
+			// we only add orderers from clusters that are in "ret", else skip this node
+			if (ret[cluster_id]) {
+				if (!osn_already_exist(cluster_id, node._id)) {	// orderer is not in map yet
+					if (node.osnadmin_url) {						// osn-join flow needs the osnadmin_url field
 						node._consenter = false;
 						ret[cluster_id].nodes.push(init_node(node, false));
 					}
@@ -418,9 +423,33 @@ class JoinOSNChannelModal extends React.Component {
 			}
 		}
 
-		// iter over joined osn to this channel and set if each osn has joined or not
-
 		return ret;
+
+		// init the "ret" field for this node's cluster
+		async function init_cluster(node_data, selected) {
+
+			// get tls identity for node
+			const identity4tls = await ChannelParticipationApi.findMatchingIdentity({
+				identities: all_identities,
+				root_certs_b64pems: _.get(node_data, 'msp.tlsca.root_certs')
+			});
+
+			return {
+				nodes: [],					// populated later
+				msp_id: node_data.msp_id,
+				cluster_name: node_data._cluster_name,
+				cluster_id: node_data._cluster_id,
+
+				// the identity we think they should use
+				tls_identity: identity4tls,
+
+				// if this cluster of orderer nodes is selected to join the channel - defaults true
+				selected: selected,
+
+				// the root certs for the MSP that controls this cluster, used later in the join-channel api
+				tls_root_certs: (msp_data && msp_data[node_data.msp_id]) ? msp_data[node_data.msp_id].tls_root_certs : [],
+			};
+		}
 
 		// sort orderer nodes, nodes that are consenters are first
 		function fancy_node_sort(arr) {
@@ -483,6 +512,17 @@ class JoinOSNChannelModal extends React.Component {
 			}
 			return null;
 		}
+
+		// figure out if this msp is a consenter or not
+		// dsh todo use root cert
+		function msp_is_consenter(msp_id, consenters) {
+			for (let i in consenters) {
+				if (consenters[i]._msp_id === msp_id) {
+					return true;
+				}
+			}
+			return false;
+		}
 	}
 
 	// ------------------------------------------------------------------------------------------------------------------------------------
@@ -537,7 +577,7 @@ class JoinOSNChannelModal extends React.Component {
 		this.props.updateState(SCOPE, {
 			config_block_b64: null,
 			loading: true,
-			drill_down_flow: true,
+			drill_down_flow: true,		// true if user clicked on specific cluster before coming to this panel
 		});
 		try {
 			const config_block_b64 = await this.getChannelConfigBlock(channelName);
@@ -613,7 +653,7 @@ class JoinOSNChannelModal extends React.Component {
 		this.props.updateState(SCOPE, {
 			config_block_b64: this.props.selectedConfigBlockDoc.block_b64,
 			loading: true,
-			drill_down_flow: true,
+			drill_down_flow: false,
 		});
 
 		try {
@@ -629,19 +669,6 @@ class JoinOSNChannelModal extends React.Component {
 				block_error: details ? details : e.toString(),
 				config_block_b64: null,
 				loading: false,
-			});
-		}
-	}
-
-	// select or unselect the cluster
-	toggleCluster = (cluster_id, evt) => {
-		let { joinOsnMap } = this.props;
-		if (joinOsnMap && joinOsnMap[cluster_id]) {
-			joinOsnMap[cluster_id].selected = !joinOsnMap[cluster_id].selected;
-			this.props.updateState(SCOPE, {
-				joinOsnMap: JSON.parse(JSON.stringify(joinOsnMap)),
-				count: this.countSelectedOrderers(joinOsnMap),
-				follower_count: this.countFollowers(joinOsnMap),
 			});
 		}
 	}
@@ -673,9 +700,7 @@ class JoinOSNChannelModal extends React.Component {
 
 		for (let cluster_id in joinOsnMap) {
 			for (let i in joinOsnMap[cluster_id].nodes) {
-				//if (!joinOsnMap[cluster_id].nodes[i]._consenter) {		// skip consenters
 				joinOsnMap[cluster_id].nodes[i]._selected = !this.props.select_all_toggle;
-				//}
 			}
 		}
 
@@ -960,26 +985,18 @@ class JoinOSNChannelModal extends React.Component {
 								toggled={select_all_toggle}
 								onToggle={this.toggleSelected}
 								onChange={() => { }}
-								aria-label={
-									drill_down_flow ?
-										select_all_toggle ? translate('unselect_all') : translate('select_all')
-										:
-										select_all_toggle ? translate('unselect_followers') : translate('select_followers')
-								}
-								labelA={drill_down_flow ? translate('select_all') : translate('select_followers')}
-								labelB={drill_down_flow ? translate('unselect_all') : translate('unselect_followers')}
+								aria-label={select_all_toggle ? translate('unselect_all') : translate('select_all')}
+								labelA={translate('select_all')}
+								labelB={translate('unselect_all')}
 							/>
 						</p>
 					)}
 
 					{!this.props.loading && joinOsnMap && !_.isEmpty(Object.keys(joinOsnMap)) && (
 						<div className="ibp-join-osn-msp-wrap">
+							<div className="ibp-join-osn-label">{translate('clusters')}:</div>
 							{Object.values(joinOsnMap).map((cluster, i) => {
-								//	if (cluster.selected === true) {
 								return (this.renderClusterSection(cluster));
-								//	}
-								//} else {
-								//	return (this.renderClusterSection(cluster));
 							})}
 						</div>
 					)}
@@ -990,30 +1007,15 @@ class JoinOSNChannelModal extends React.Component {
 
 	// create the cluster section (this contains each node)
 	renderClusterSection(cluster) {
-		const { translate, drill_down_flow } = this.props;
-		const unselectedClass = (cluster.selected === true) ? '' : 'ibp-join-unselected-cluster';
-
 		return (
 			<div key={'cluster_' + cluster.cluster_id}
 				className="ibp-join-osn-wrap"
 			>
 				<div>
-					{!drill_down_flow && <input type="checkbox"
-						className="ibp-join-osn-cluster-check"
-						checked={cluster.selected === true}
-						name={'joinCluster' + cluster.cluster_id}
-						id={'joinCluster' + cluster.cluster_id}
-						onChange={event => {
-							this.toggleCluster(cluster.cluster_id, event);
-						}}
-						disabled={!cluster.tls_identity}
-					/>}
-
 					<label name={'joinCluster' + cluster.cluster_id}
 						className="ibp-join-osn-cluster-wrap"
 					>
-						<div className="ibp-join-osn-label">{translate('cluster')}:</div>
-						<div className={'ibp-join-osn-clusterid ' + unselectedClass}>{cluster.cluster_name}</div>
+						<div className={'ibp-join-osn-clusterid'}>{cluster.cluster_name}</div>
 					</label>
 				</div >
 				<div>{this.renderNodesSection(cluster.nodes, cluster)}</div>
@@ -1024,7 +1026,6 @@ class JoinOSNChannelModal extends React.Component {
 	// create the line for an orderer node
 	renderNodesSection(nodes, cluster) {
 		const { translate } = this.props;
-		const unselectedClass = (cluster.selected === true) ? '' : ' ibp-join-unselected-cluster';
 
 		if (Array.isArray(nodes)) {
 			return (nodes.map((node, i) => {
@@ -1045,7 +1046,7 @@ class JoinOSNChannelModal extends React.Component {
 				const hasJoinedChannel = (node._status === constants.OSN_JOIN_SUCCESS);
 
 				return (
-					<div className={'ibp-join-osn-node-wrap-wrap' + unselectedClass}
+					<div className={'ibp-join-osn-node-wrap-wrap'}
 						key={'node-wrap-' + i}
 					>
 						<div className={'ibp-join-osn-node-wrap ' + statusClassBorder}
@@ -1064,11 +1065,11 @@ class JoinOSNChannelModal extends React.Component {
 								title={(hasJoinedChannel) ? translate('already_joined') : (node._consenter === true ? 'Node is a consenter' : 'Node is a follower')}
 							/>
 							<div className="ibp-join-osn-name">{node.name}</div>
-							<span className="ibp-join-osn-node-details">
+							<div className="ibp-join-osn-node-details">
 								<div className="ibp-join-osn-host">
 									{label} - {node.host}:{node.port}
 								</div>
-							</span>
+							</div>
 							<span className={'ibp-join-osn-status ' + statusClassIcon}>
 								{this.renderStatusIcon(node._status, hasJoinedChannel)}
 							</span>

--- a/packages/apollo/src/components/JoinOSNChannelModal/_joinOSNChannelModal.scss
+++ b/packages/apollo/src/components/JoinOSNChannelModal/_joinOSNChannelModal.scss
@@ -101,7 +101,7 @@
 
 .ibp-join-osn-wrap {
 	margin-bottom: 2rem;
-	border-left: 3px #505355 solid;
+	border-left: 2px #505355 solid;
 	padding-left: 0.25rem;
 }
 
@@ -136,14 +136,13 @@
 
 .ibp-join-osn-cluster-wrap {
 	font-size: 1.1rem;
-	margin: 0 1rem;
+	margin: 0 0.6rem;
 	display: inline-block;
 	vertical-align: top;
-	margin-top: 0.6rem;
 }
 
 .ibp-join-osn-node-wrap-wrap {
-	margin-left: 2.3rem;
+	margin-left: 2rem;
 	margin-bottom: 0.5rem;
 	width: 85%;
 	max-width: 55rem;
@@ -181,7 +180,7 @@
 	width: 2rem;
 	position: absolute;
 	right: 0;
-	top: 0.8rem;
+	top: 1.3rem;
 	color: #0f62fe;
 }
 
@@ -205,12 +204,14 @@
 }
 
 .ibp-join-osn-node-details {
-	display: inline-block;
+	display: block;
 	font-weight: 400;
+	margin-left: 1.7rem;
+	max-width: 92%;
 }
 
 .ibp-join-osn-label {
-	font-size: 0.75rem;
+	font-size: 1rem;
 	font-weight: 400;
 	line-height: 1.34;
 	letter-spacing: 0.32px;
@@ -229,7 +230,7 @@
 }
 
 .ibp-join-osn-msp-wrap {
-	max-height: 18rem;
+	max-height: 23rem;
 	overflow-y: scroll;
 	margin-top: 2rem;
 }
@@ -238,6 +239,7 @@
 	min-width: 35rem;
 	padding: 1.5rem;
 	padding-top: 0rem;
+	padding-bottom: 1rem;
 }
 
 .ibp-join-osn-count {


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
- the node options listed during a  systemless-channel orderer join were not as lax as they should be. this pr allows selecting nodes from any cluster that has the same MSP. 

