### PR TITLE
parse config block Endpoints -> addressess safely

### DIFF
--- a/packages/apollo/src/rest/ChannelApi.js
+++ b/packages/apollo/src/rest/ChannelApi.js
@@ -577,7 +577,10 @@ class ChannelApi {
 		if (addresses.length === 0) {
 			const orderer_grp = _.get(config, 'channel_group.groups_map.Orderer.groups_map');
 			for (let ordererMSP in orderer_grp) {
-				addresses.push(...orderer_grp[ordererMSP].values_map.Endpoints.value.addresses);
+				const org_addresses = _.get(orderer_grp[ordererMSP], 'values_map.Endpoints.value.addresses');
+				if (Array.isArray(org_addresses)) {
+					addresses.push(...org_addresses);
+				}
 			}
 		}
 		return addresses;


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
Handle empty or undefined values for  `Endpoints.value.addresses` in a config block. This fixes an error when joining a peer to a channel that has an orderer org with zero orderers.

