### PR TITLE
add npm flag to fix build with react deps

### DIFF
--- a/docker/console/Dockerfile
+++ b/docker/console/Dockerfile
@@ -48,7 +48,7 @@ RUN chown -R 1001:0 .
 RUN ls -ld .
 USER 1001
 RUN cp $STITCH_DIR/dist/* $APOLLO_DIR/public/
-RUN npm ci && npm run build
+RUN npm ci --legacy-peer-deps && npm run build
 
 # look at apollo output...
 RUN ls -l $APOLLO_DIR/build


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
The command `npm ci` is failing under apollo, due to conflicting react dependency versions. this fixes the error.

