### PR TITLE
pin detect secrets to .52

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           node-version: 16.x
       - name: Install detect-secrets
-        run: pip install --upgrade git+https://github.com/ibm/detect-secrets.git@master#egg=detect-secrets
+        run: pip install --upgrade git+https://github.com/ibm/detect-secrets.git@0.13.1+ibm.52.dss#egg=detect-secrets
       - name: Install Lerna
         run: npm install -g lerna
       - name: Run detect-secrets


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Test update

#### Description
Use a specific version of detect secrets to avoid breaking builds when a new one is released.

