### PR TITLE
change start command

### DIFF
--- a/docker/console/Dockerfile
+++ b/docker/console/Dockerfile
@@ -108,4 +108,4 @@ RUN ls -l $SERVER_HOME
 # Fin
 EXPOSE 3000
 USER 1001
-CMD [ "npm", "start" ]
+CMD [ "node", "server_watcher.js" ]


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
There is some sort of permission error, trying to change the start command from `npm start` to `node server_watcher.js`.

