### PR TITLE
Bug fix when adding ordering nodes to channel

### DIFF
--- a/packages/apollo/src/components/JoinOSNChannelModal/JoinOSNChannelModal.js
+++ b/packages/apollo/src/components/JoinOSNChannelModal/JoinOSNChannelModal.js
@@ -203,8 +203,8 @@ class JoinOSNChannelModal extends React.Component {
 			let urlObj = (typeof node.backend_addr === 'string') ? url.parse(node.backend_addr.toLowerCase()) : null;
 			const tls_cert = _.get(node, 'msp.component.tls_cert');
 
-			// consenters must have a tls certificate and host/port data
-			if (urlObj && urlObj.hostname && urlObj.port && tls_cert) {
+			// consenters must have a tls certificate, host/port data and no system channel
+			if (urlObj && urlObj.hostname && urlObj.port && tls_cert && node.systemless) {
 				possible_consenters.push({				// leading underscores denote field is not used by fabric
 					name: node.display_name,
 					msp_id: node.msp_id,


### PR DESCRIPTION
Signed-off-by: Nikhil Modem <Nikhil.Modem@ibm.com>

#### Type of change
- Bug fix

#### Description
- If an ordering cluster has nodes with the system channel, they were available to add to a channel. The entire cluster should not show up in this case.
- If an ordering cluster has nodes both with and without the system channel, all node were available to add to the channel. The cluster should show up, but only the nodes that do not have a system channel should show up in this case.
- Both of the above scenarios are dealt with by only returning nodes that do not have a system channel, regardless of the overall cluster configuration.

