### PR TITLE
don't show the migrated console banner

### DIFF
--- a/packages/apollo/src/components/PageHeader/PageHeader.js
+++ b/packages/apollo/src/components/PageHeader/PageHeader.js
@@ -160,7 +160,7 @@ export class PageHeader extends Component {
 		migrationState = {
 			isMigrationAvailable: false,
 			isMigrationDone: false,
-			isMigrationComplete: true,
+			isMigrationComplete: false,
 			migratedConsoleUrl: 'https://www.new-console-url.com'
 		};
 
@@ -439,7 +439,7 @@ export class PageHeader extends Component {
 				)}
 				{this.props.showAnnouncement && this.props.isMigrationComplete && (
 					<InlineNotification
-						kind="warning"
+						kind="error"
 						hideCloseButton
 						actions={
 							<NotificationActionButton

--- a/packages/apollo/src/components/TitleBar/_titleBar.scss
+++ b/packages/apollo/src/components/TitleBar/_titleBar.scss
@@ -159,6 +159,10 @@
 			display: block;
 		}
 	}
+
+	.bx--header-read-only {
+		background-color: #da1e28;
+	}
 }
 
 .bx--skip-to-content {


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
The new migration banner was left visible, accidentally. It should only show after a console has migrated.

