### PR TITLE
non admin didentity message no longer appears on ca details page.

### DIFF
--- a/packages/apollo/src/components/CADetails/CADetails.js
+++ b/packages/apollo/src/components/CADetails/CADetails.js
@@ -589,16 +589,16 @@ export class CADetails extends Component {
 		const translate = this.props.translate;
 		return (
 			<PageContainer>
+				<PageHeader
+					history={this.props.history}
+					headerName={caName ? translate('ca_details_title', { caName: caName }) : ''}
+				/>
+				{caNameSkeleton}
 				<div className="ibp-ca-details bx--row">
 					<div className="bx--col-lg-4">
 						<div className="ibp-node-details-panel">
 							<div className="ibp-node-tags" />
 							<div className="ibp-node-details-header">
-								<PageHeader
-									history={this.props.history}
-									headerName={caName ? translate('ca_details_title', { caName: caName }) : ''}
-								/>
-								{caNameSkeleton}
 								<StickySection
 									openSettings={this.openCASettings}
 									details={this.props.details}
@@ -643,16 +643,16 @@ export class CADetails extends Component {
 												this.props.details.isUpgradeAvailable &&
 												this.props.details.location === 'ibm_saas' &&
 												ActionsHelper.canCreateComponent(this.props.userInfo) ? (
-													<div className="ibp-details-patch-container">
-														<div className="ibp-patch-available-tag ibp-node-details"
-															onClick={() => this.openCASettings('upgrade')}
-														>
-															{translate('patch_available')}
-														</div>
+												<div className="ibp-details-patch-container">
+													<div className="ibp-patch-available-tag ibp-node-details"
+														onClick={() => this.openCASettings('upgrade')}
+													>
+														{translate('patch_available')}
 													</div>
-												) : (
-													''
-												),
+												</div>
+											) : (
+												''
+											),
 									})}
 								>
 									{this.renderUsage(translate)}

--- a/packages/apollo/src/components/IdentityExpiration/IdentityExpiration.js
+++ b/packages/apollo/src/components/IdentityExpiration/IdentityExpiration.js
@@ -91,6 +91,10 @@ class IdentityExpiration extends Component {
 				}
 			});
 		}
+		// If component is a ca, set admin to true so non-admin message doesn't appear
+		if (this.props.details && this.props.details.node_type === 'fabric-ca') {
+			admin = true;
+		}
 		this.props.updateState(scope, { admin });
 	}
 


### PR DESCRIPTION
Signed-off-by: Nikhil Modem <Nikhil.Modem@ibm.com>

#### Type of change

- Bug fix
- Improvement (improvement to code, performance, etc)

#### Description
- Non-admin identity message appeared for associated identities of CAs which didn't make sense so took it out.
-  Also moved PageHeader component on CA details page to reflect other pages. This makes the migration banners present better too.

