### PR TITLE
add back the setPlatform call

### DIFF
--- a/packages/apollo/src/App.js
+++ b/packages/apollo/src/App.js
@@ -233,6 +233,9 @@ class App extends Component {
 
 		// use setPlatform() after setInfrastructure() to make sure "platform" is set correctly
 		// b/c we trust settings.INFRASTRUCTURE and don't trust FEATURE_FLAGS.infra_import_options.platform
+		if (settings.INFRASTRUCTURE) {
+			Helper.setPlatform(settings.INFRASTRUCTURE);
+		}
 		if (features.cluster_data.type === null) {
 			let serviceInfo = null;
 			try {


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
Bring back the setPlatform call in App.js to correctly set the `Helper.infrastructure.platform` field.

