### PR TITLE
fix admin cert sync when updating msp

### DIFF
--- a/packages/apollo/src/rest/NodeRestApi.js
+++ b/packages/apollo/src/rest/NodeRestApi.js
@@ -852,7 +852,8 @@ class NodeRestApi {
 			} else {
 				Log.debug('Updating admin certs for peer ', node.id, ' to ', addAdminCerts);
 				try {
-					const resp = await NodeRestApi.uploadAdminCerts(node.id, addAdminCerts, node.admin_certs);
+					const better_node = await NodeRestApi.getUnCachedDataWithDeployerAttrs(node.id);
+					const resp = await NodeRestApi.uploadAdminCerts(node.id, addAdminCerts, better_node.admin_certs);
 					Log.debug('Update admin cert response:', resp);
 				} catch (error) {
 					Log.error('An error occurred when updating admin cert for peer ', node);


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
When updating an MSP, the admin certs on a peer were not being synchronized correctly. Admin certs could be added but not removed. This PR fixes that.
