### PR TITLE
Fixing chaincode instantiation filtering

### DIFF
--- a/packages/apollo/src/components/InstantiateChaincodeModal/InstantiateChaincodeModal.js
+++ b/packages/apollo/src/components/InstantiateChaincodeModal/InstantiateChaincodeModal.js
@@ -664,12 +664,12 @@ class InstantiateChaincodeModal extends Component {
 							!this.props.showOrdererDropdown &&
 							!_.has(this.props.selectedOrderer, 'url2use') &&
 							!this.props.error && (
-								<div className="ibp-modal-desc">
-									<SidePanelWarning title={translate('channel_orderer_not_found')}
-										subtitle={translate('channel_orderer_not_imported_desc')}
-									/>
-								</div>
-							)}
+							<div className="ibp-modal-desc">
+								<SidePanelWarning title={translate('channel_orderer_not_found')}
+									subtitle={translate('channel_orderer_not_imported_desc')}
+								/>
+							</div>
+						)}
 					</div>
 				)}
 			</WizardStep>
@@ -1064,7 +1064,7 @@ class InstantiateChaincodeModal extends Component {
 				onSubmit={this.onSubmit}
 				submitButtonLabel={this.props.isUpgrade ? translate('upgrade_smc') : translate('instantiate_smc')}
 				error={this.props.error}
-			//loading={this.props.loading}
+				//loading={this.props.loading}
 			>
 				<p className="ibp-modal-desc">
 					{this.props.isUpgrade ? (

--- a/packages/apollo/src/components/PageHeader/PageHeader.js
+++ b/packages/apollo/src/components/PageHeader/PageHeader.js
@@ -94,12 +94,9 @@ export class PageHeader extends Component {
 		let migrationState = {};
 
 		let migrationStatusResp = null;
-		let settingsResp = null;
 
 		try {
 			migrationStatusResp = await MigrationApi.getStatus();
-			settingsResp = await SettingsApi.getSettings();
-			console.log('Nik', settingsResp);
 		} catch (e) {
 			console.log('Announcement Error displayMigrationBanner', e);
 		}


### PR DESCRIPTION
Signed-off-by: Nikhil Modem [Nikhil.Modem@ibm.com](mailto:Nikhil.Modem@ibm.com)

#### Type of change

- Bug fix

#### Description
- Filtering of peers to be used to submit an instantiation or upgrade to was broken due to the way policy msp id's were retrieved from a peer
- Fixed the lodash get to retrieve the identities properly
- Added some logic to the mapping to extract just the msp id string from the Uint8Array that is returned
- Also removed some logging that was left in from a previous PR

