### PR TITLE
Test case updates to cover 2.2.x to 2.4.x migration via console

### DIFF
--- a/packages/apollo/test/functional/features/2-BuildANetwork.feature
+++ b/packages/apollo/test/functional/features/2-BuildANetwork.feature
@@ -70,13 +70,14 @@ Feature: Build a network feature
         And I selected 'peer1' from the 'div#saasCA-enroll_id' dropdown
         And I provided 'peer1pw' for the 'Enter a secret' input
         And I selected 'Org1 MSP' from the 'div#saasCA-admin_msp' dropdown
-        And I selected '2.4' matching value from the 'div#importPeerModal-version-version' dropdown
+        And I selected '2.2' matching value from the 'div#importPeerModal-version-version' dropdown
         And I clicked the button with text 'Next'
         And I selected 'Org1 MSP Admin' from the 'div#importPeerModal-identity-identity' dropdown
         And I clicked the button with text 'Next'
         When I click the button with text 'Add peer'
         Then I should see a success toast which says "Congratulations! You have successfully created 'Peer Org1'"
         And the peer with name 'Peer Org1' should have started successfully
+
 
     Scenario: When creating a certificate authority for the Ordering Service
         Given I go to the console
@@ -160,7 +161,7 @@ Feature: Build a network feature
         And I selected 'OS1' from the 'div#saasCA-enroll_id' dropdown
         And I provided 'OS1pw' for the 'Enter a secret' input
         And I selected 'Ordering Service MSP' value from the 'div#saasCA-admin_msp' dropdown
-        And I selected '2.4' matching value from the 'div#importOrdererModal-version-version' dropdown
+        And I selected '2.2' matching value from the 'div#importOrdererModal-version-version' dropdown
         And I clicked the button with text 'Next'
         Then wait "5" seconds
         And I selected 'Ordering Service MSP Admin' value from the 'div#importOrdererModal-identity' dropdown
@@ -181,3 +182,4 @@ Feature: Build a network feature
         When I click the button with text 'Add organization'
         Then wait "10" seconds
         Then a tile with title 'Org1 MSP' should have been created
+

--- a/packages/apollo/test/functional/features/2-BuildANetwork.feature
+++ b/packages/apollo/test/functional/features/2-BuildANetwork.feature
@@ -76,6 +76,7 @@ Feature: Build a network feature
         And I clicked the button with text 'Next'
         When I click the button with text 'Add peer'
         Then I should see a success toast which says "Congratulations! You have successfully created 'Peer Org1'"
+        Then wait "30" seconds
         And the peer with name 'Peer Org1' should have started successfully
 
 

--- a/packages/apollo/test/functional/features/9-BuildANetwork_Without_SysChannel.feature
+++ b/packages/apollo/test/functional/features/9-BuildANetwork_Without_SysChannel.feature
@@ -1,7 +1,37 @@
 @saas @software @saas-minimal
 Feature: Build a network without system channel
 
-	Scenario: When creating an ordering service without system channel
+
+  Scenario: Upgrading Peer and Ordering Service node to v2.4.x
+      Given I go to the console
+      And I am logged in
+      And I am ready to get started
+      And I am on the 'nodes' page
+      And I clicked the 'Peer Org1' peer
+      And I clicked the button with id 'ibp-peer-usage'
+      And I clicked the button with id 'patch_node'
+      And I clicked the checkbox with text 'I understand this is a potentially breaking change. Upgrade anyway.'
+      And I clicked the button with text 'Next'
+      And I provided 'Peer Org1' for the 'Type node name here' input
+      And I clicked the button with text 'Upgrade Fabric version'
+      Then wait "20" seconds
+      And I am on the 'nodes' page
+      And the peer with name 'Peer Org1' should have started successfully
+      And I am on the 'nodes' page
+      And I clicked the 'Ordering Service' orderer
+      Then wait "10" seconds
+      And I clicked the button with id 'ibp-orderer-nodes'
+      And I clicked the button with id 'ibp-tile-Ordering Service_1'
+      And I clicked the button with text 'Upgrade version'
+      And I clicked the button with text 'Next'
+      And I provided 'Ordering Service_1' for the 'Type node name here' input
+      And I clicked the button with text 'Upgrade Fabric version'
+      Then wait "10" seconds
+      And I am on the 'nodes' page
+      And the orderer with name 'Ordering Service' should have started successfully
+
+
+  Scenario: When creating an ordering service without system channel
         Given I go to the console
         And I am logged in
         And I am ready to get started

--- a/packages/apollo/test/functional/steps/node.steps.js
+++ b/packages/apollo/test/functional/steps/node.steps.js
@@ -53,8 +53,11 @@ Then(/^the (certificate authority|peer|orderer) with name (?:'|")(.*?)(?:'|") sh
 		await browser.wait(ExpectedConditions.elementToBeClickable(isRunning), 10 * 60 * 1000);
 	}
 
+    // Sometimes peer node takes little longer - so added extra 2 minutes of wait for Peer and Ordering service node to come up
+    if (nodeType != 'certificate authority') {
     console.log('Wait for 2 minutes...');
     await browser.sleep(120000);
+    }
 	await tile.click();
 });
 


### PR DESCRIPTION
#### Type of change
- Test update

#### Description
Added test scenario to created one peer and orderer in 2.2.x and then upgrade them from console to 2.4.x and perform workflow without system channel