### PR TITLE
propagate "migrated_from" through export & import

### DIFF
--- a/packages/apollo/src/components/ImportCAModal/ImportCAModal.js
+++ b/packages/apollo/src/components/ImportCAModal/ImportCAModal.js
@@ -521,6 +521,10 @@ class ImportCAModal extends React.Component {
 							validate: Helper.isCertificate,
 						},
 						{
+							name: 'migrated_from',
+							required: false,
+						},
+						{
 							name: 'msp',
 							required: false,
 							validate: msp => {

--- a/packages/apollo/src/components/ImportOrdererModal/ImportOrdererModal.js
+++ b/packages/apollo/src/components/ImportOrdererModal/ImportOrdererModal.js
@@ -1118,6 +1118,10 @@ class ImportOrdererModal extends React.Component {
 											required: true,
 										},
 										{
+											name: 'migrated_from',
+											required: false,
+										},
+										{
 											name: 'msp_id',
 											required: true,
 											specialRules: Helper.SPECIAL_RULES_MSP_ID,

--- a/packages/apollo/src/components/ImportPeerModal/ImportPeerModal.js
+++ b/packages/apollo/src/components/ImportPeerModal/ImportPeerModal.js
@@ -914,6 +914,10 @@ class ImportPeerModal extends React.Component {
 							required: false,
 						},
 						{
+							name: 'migrated_from',
+							required: false,
+						},
+						{
 							name: 'type',
 							required: false,
 							validate: value => {

--- a/packages/apollo/src/components/JsonInput/JsonInput.js
+++ b/packages/apollo/src/components/JsonInput/JsonInput.js
@@ -105,6 +105,7 @@ export class JsonInput extends React.Component {
 
 	checkDefinition(json) {
 		// todo why can't we just pass this component a validation function?  What if I need something this definition format doesn't provide, like alternative sets of params?
+		// whoever wrote ^^, i agree! this flow bites
 		const check = {
 			key: json.key ? json.key : 'key_' + this.nextKey++,
 			error: null,
@@ -222,6 +223,8 @@ export class JsonInput extends React.Component {
 		return check;
 	}
 
+	// when used with the JsonInput component, this will parse the json file and set "this.props.data" to only
+	// have fields defined in the <JsonInput>'s "definition" field
 	onFileUpload = event => {
 		const all = [];
 		for (let i = 0; i < event.target.files.length; i++) {
@@ -245,6 +248,7 @@ export class JsonInput extends React.Component {
 						const raft = {};
 						result.json.forEach(entry => {
 							if (entry.cluster_id) {
+								// this only returns fields from "entry" that are defined in the react component's "definition" variable
 								const check = this.checkDefinition(entry);
 								if (raft[entry.cluster_id]) {
 									raft[entry.cluster_id].raft.push(entry);
@@ -260,10 +264,12 @@ export class JsonInput extends React.Component {
 									data.push(raft[entry.cluster_id]);
 								}
 							} else {
+								// this only returns fields from "entry" that are defined in the react component's "definition" variable
 								data.push(this.checkDefinition(entry));
 							}
 						});
 					} else {
+						/// this only returns fields from "entry" that are defined in the react component's "definition" variable
 						data.push(this.checkDefinition(result.json));
 					}
 				}

--- a/packages/apollo/src/rest/CertificateAuthorityRestApi.js
+++ b/packages/apollo/src/rest/CertificateAuthorityRestApi.js
@@ -59,6 +59,7 @@ class CertificateAuthorityRestApi {
 						tls_cert: some_ca_record.tls_cert,
 					},
 				},
+				migrated_from: some_ca_record.migrated_from ? some_ca_record.migrated_from : undefined,
 			};
 			return NodeRestApi.importComponent(exported_ca);
 		});

--- a/packages/apollo/src/rest/MspRestApi.js
+++ b/packages/apollo/src/rest/MspRestApi.js
@@ -80,6 +80,7 @@ class MspRestApi {
 			organizational_unit_identifiers: exported_msp.organizational_unit_identifiers,
 			fabric_node_ous: exported_msp.fabric_node_ous,
 			host_url: exported_msp.host_url,
+			migrated_from: exported_msp.migrated_from ? exported_msp.migrated_from : undefined,
 		};
 		return NodeRestApi.importComponent(exportedMSP);
 	}

--- a/packages/apollo/src/rest/OrdererRestApi.js
+++ b/packages/apollo/src/rest/OrdererRestApi.js
@@ -127,6 +127,7 @@ class OrdererRestApi {
 					cluster_id: node.cluster_id,
 					cluster_name: node.cluster_name,
 					msp: node.msp,
+					migrated_from: node.migrated_from ? node.migrated_from : undefined,
 				};
 				if (!_.get(newOrderer, 'msp.component.tls_cert')) {
 					_.set(newOrderer, 'msp.component.tls_cert', node.tls_cert || node.server_tls_cert);

--- a/packages/apollo/src/rest/PeerRestApi.js
+++ b/packages/apollo/src/rest/PeerRestApi.js
@@ -427,6 +427,7 @@ class PeerRestApi {
 				grpcwp_url: Helper.normalizeHttpURL(some_peer_record.grpcwp_url),
 				msp_id: some_peer_record.msp_id,
 				msp: some_peer_record.msp,
+				migrated_from: some_peer_record.migrated_from ? some_peer_record.migrated_from : undefined,
 			};
 			if (!_.get(exportedPeer, 'msp.component.tls_cert')) {
 				_.set(exportedPeer, 'msp.component.tls_cert', some_peer_record.tls_cert);

--- a/packages/athena/json_docs/json_validation/ibp_openapi_v3.yaml
+++ b/packages/athena/json_docs/json_validation/ibp_openapi_v3.yaml
@@ -11429,6 +11429,11 @@ components:
       x-validate_illegal_values:
         - '.'
         - '..'
+    migrated_from:
+      type: string
+      example: ibm_saas
+      description: This is an internal field to reference if a component came from a different console. It can be left blank.
+      maxLength: 128
     api_url_ca:
       type: string
       description: The URL for the CA. Typically, client applications would send requests to this URL. Include the protocol, hostname/ip and port.
@@ -14906,6 +14911,8 @@ components:
           $ref: '#/components/schemas/location_saas'
         api_url:
           $ref: '#/components/schemas/api_url_ca'
+        migrated_from:
+          $ref: '#/components/schemas/migrated_from'
         operations_url:
           $ref: '#/components/schemas/operations_url_ca'
         tags:
@@ -15000,6 +15007,8 @@ components:
           $ref: '#/components/schemas/osnadmin_url_orderer'
         location:
           $ref: '#/components/schemas/location_saas'
+        migrated_from:
+          $ref: '#/components/schemas/migrated_from'
         msp:
           $ref: '#/components/schemas/msp_crypto_field'
         msp_id:
@@ -15033,6 +15042,8 @@ components:
           $ref: '#/components/schemas/grpcwp_url_peer'
         location:
           $ref: '#/components/schemas/location_saas'
+        migrated_from:
+          $ref: '#/components/schemas/migrated_from'
         msp:
           $ref: '#/components/schemas/msp_crypto_field'
         msp_id:

--- a/packages/athena/libs/comp_formatting_lib.js
+++ b/packages/athena/libs/comp_formatting_lib.js
@@ -443,6 +443,10 @@ module.exports = function (logger, ev, t) {
 		}
 		component_doc.tags = t.component_lib.fmt_tags(component_doc.tags);			// format and remove duplicates
 
+		if (incoming_body.migrated_from) {
+			component_doc.migrated_from = incoming_body.migrated_from;
+		}
+
 		// capture other body fields
 		if (outgoing_body) {
 			if (outgoing_body.cluster_name) {


### PR DESCRIPTION
Signed-off-by: David Huffman <dshuffma@us.ibm.com>

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- New feature


#### Description
A new field called `migrated_from` will appear (if its populated) in exports, and will be stored if imported. This will track components being moved from one console to another.

