### PR TITLE
prevent doc conflicts during restore

### DIFF
--- a/packages/athena/public/releaseNotes.json
+++ b/packages/athena/public/releaseNotes.json
@@ -1,7 +1,7 @@
 [
 	{
-		"version": "1.0.4-10",
-		"date": "21 Feb 2023",
+		"version": "1.0.4-13",
+		"date": "22 Feb 2023",
 		"description": [
 			{
 				"title": "Bug & security fixes",


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
During a restore, if a doc doesn't exist it will causes a conflict when writing the doc (paradoxically). this PR fixes that.

