### PR TITLE
disable more buttons if in read only mode

### DIFF
--- a/packages/apollo/src/components/CADetails/CADetails.js
+++ b/packages/apollo/src/components/CADetails/CADetails.js
@@ -507,7 +507,7 @@ export class CADetails extends Component {
 									{
 										text: 'reallocate_resources',
 										fn: this.showUsageModal,
-										disabled: !ActionsHelper.canEditComponent(this.props.feature_flags)
+										disabled: !ActionsHelper.canEditComponent(this.props.feature_flags),
 									},
 								]}
 							/>

--- a/packages/apollo/src/components/Chaincodes/Chaincodes.js
+++ b/packages/apollo/src/components/Chaincodes/Chaincodes.js
@@ -24,6 +24,7 @@ import Helper from '../../utils/helper';
 import InstallChaincodeModal from '../InstallChaincodeModal/InstallChaincodeModal';
 import InstantiateChaincodeModal from '../InstantiateChaincodeModal/InstantiateChaincodeModal';
 import ItemContainer from '../ItemContainer/ItemContainer';
+import ActionsHelper from '../../utils/actionsHelper';
 
 const SCOPE = 'chaincodes';
 
@@ -143,6 +144,7 @@ class Chaincodes extends Component {
 								text: 'install_chaincode',
 								fn: this.openInstallChaincodeModal,
 								label: 'install_chaincode',
+								disabled: !ActionsHelper.canEditComponent(this.props.feature_flags)
 							},
 						]}
 						disableAddItem={!this.props.peers || this.props.peers.length === 0}

--- a/packages/apollo/src/components/ChaincodesPage/ChaincodesPage.js
+++ b/packages/apollo/src/components/ChaincodesPage/ChaincodesPage.js
@@ -200,6 +200,7 @@ class ChaincodesPage extends Component {
 								loading={this.props.loading}
 								installedChaincodeList={this.props.chaincodeList}
 								instantiatedChaincodeList={this.props.instantiated_array}
+								feature_flags={this.props.feature_flags}
 							/>
 						</div>
 
@@ -240,6 +241,7 @@ export default connect(
 		let newProps = Helper.mapStateToProps(state[SCOPE], dataProps);
 		newProps['host_url'] = state['settings'] ? state['settings']['host_url'] : null;
 		newProps['docPrefix'] = state['settings'] ? state['settings']['docPrefix'] : null;
+		newProps['feature_flags'] = state['settings'] ? state['settings']['feature_flags'] : null;
 		return newProps;
 	},
 	{

--- a/packages/apollo/src/components/ChannelChaincode/ChannelChaincode.js
+++ b/packages/apollo/src/components/ChannelChaincode/ChannelChaincode.js
@@ -29,6 +29,7 @@ import ChaincodeModal from '../ChaincodeModal/ChaincodeModal';
 import ItemContainer from '../ItemContainer/ItemContainer';
 import Logger from '../Log/Logger';
 import ProposeChaincodeModal from '../ProposeChaincodeModal/ProposeChaincodeModal';
+import ActionsHelper from '../../utils/actionsHelper';
 
 const SCOPE = 'channelChaincode';
 const Log = new Logger(SCOPE);
@@ -250,6 +251,7 @@ class ChannelChaincode extends Component {
 						{
 							text: 'chaincode_propose',
 							fn: this.openProposeChaincodeModal,
+							disabled: !ActionsHelper.canEditComponent(this.props.feature_flags)
 						},
 					]}
 					select={this.openChaincodeModal}
@@ -310,6 +312,7 @@ export default connect(
 	state => {
 		let newProps = Helper.mapStateToProps(state[SCOPE], dataProps);
 		newProps['docPrefix'] = state['settings'] ? state['settings']['docPrefix'] : null;
+		newProps['feature_flags'] = state['settings'] ? state['settings']['feature_flags'] : null;
 		return newProps;
 	},
 	{

--- a/packages/apollo/src/components/ChannelDetails/ChannelDetails.js
+++ b/packages/apollo/src/components/ChannelDetails/ChannelDetails.js
@@ -43,6 +43,7 @@ import Logger from '../Log/Logger';
 import PageContainer from '../PageContainer/PageContainer';
 import PageHeader from '../PageHeader/PageHeader';
 import StickySection from '../StickySection/StickySection';
+import ActionsHelper from '../../utils/actionsHelper';
 
 const SCOPE = 'channelDetails';
 const Log = new Logger(SCOPE);
@@ -419,8 +420,7 @@ class ChannelDetails extends Component {
 							});
 							this.allOrderers = orderers;
 							this.consenters = l_consenters;
-							if (this.props.ordererList.length < 1)
-							{
+							if (this.props.ordererList.length < 1) {
 								this.props.updateState(SCOPE, {
 									ordererCheck: false,
 								});
@@ -956,6 +956,7 @@ class ChannelDetails extends Component {
 							id: 'add_node',
 							text: 'add_node',
 							fn: this.showJoinChannelModal,
+							disabled: !ActionsHelper.canEditComponent(this.props.feature_flags)
 						},
 					]}
 				/>
@@ -1229,7 +1230,7 @@ class ChannelDetails extends Component {
 							hideExport
 							hideDelete
 							hideRefreshCerts
-							feature_flags
+							feature_flags={this.props.feature_flags}
 							userInfo
 						/>
 					</div>
@@ -1390,6 +1391,7 @@ export default connect(
 		let newProps = Helper.mapStateToProps(state[SCOPE], dataProps);
 		newProps['settings'] = state['settings'];
 		newProps['configtxlator_url'] = state['settings']['configtxlator_url'];
+		newProps['feature_flags'] = state['settings'] ? state['settings']['feature_flags'] : null;
 		return newProps;
 	},
 	{

--- a/packages/apollo/src/components/PeerChaincode/PeerChaincode.js
+++ b/packages/apollo/src/components/PeerChaincode/PeerChaincode.js
@@ -25,6 +25,7 @@ import Helper from '../../utils/helper';
 import InstallChaincodeModal from '../InstallChaincodeModal/InstallChaincodeModal';
 import ItemContainer from '../ItemContainer/ItemContainer';
 import Logger from '../Log/Logger';
+import ActionsHelper from '../../utils/actionsHelper';
 
 const SCOPE = 'peerChaincode';
 const Log = new Logger(SCOPE);
@@ -209,6 +210,7 @@ class PeerChaincode extends Component {
 							text: 'install_chaincode',
 							fn: this.openInstallChaincodeModal,
 							label: 'install_chaincode',
+							disabled: !ActionsHelper.canEditComponent(this.props.feature_flags)
 						},
 					]}
 					disableAddItem={this.props.empty || this.props.parentLoading || this.props.state !== STATES.READY}

--- a/packages/apollo/src/components/PeerDetails/PeerDetails.js
+++ b/packages/apollo/src/components/PeerDetails/PeerDetails.js
@@ -599,6 +599,7 @@ class PeerDetails extends Component {
 											<PeerChaincode match={this.props.match}
 												peer={this.props.details}
 												parentLoading={this.props.loading}
+												feature_flags={this.props.feature_flags}
 											/>
 										</div>
 									)}

--- a/packages/athena/json_docs/default_settings_doc.json
+++ b/packages/athena/json_docs/default_settings_doc.json
@@ -178,7 +178,7 @@
 		"fabric-ca": "1.5.5",
 		"fabric-peer": "2.2.10",
 		"fabric-orderer": "2.2.10",
-		"kubernetes": "1.23"
+		"kubernetes": "1.22"
 	},
 	"migration_mon_inter_secs": 15,
 	"migration_status": {


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
A few buttons were left enabled, this disables them when the console is in read-only mode.

