### PR TITLE
Add endpoint to determine if clustertype is openshift or k8s

### DIFF
--- a/packages/fabric-deployer/deployer/components/ca/ca.go
+++ b/packages/fabric-deployer/deployer/components/ca/ca.go
@@ -66,6 +66,7 @@ type Kube interface {
 	GetConfigMap(namespace, name string) (*corev1.ConfigMap, error)
 	GetPort(namespace, name string) (int32, error)
 	GetPorts(namespace, name string) ([]corev1.ServicePort, error)
+	ClusterType(namespace string) string
 }
 
 //go:generate counterfeiter -o mocks/ibp_client.go -fake-name IBPOperatorClient . IBPOperatorClient

--- a/packages/fabric-deployer/deployer/components/ca/get.go
+++ b/packages/fabric-deployer/deployer/components/ca/get.go
@@ -26,6 +26,7 @@ import (
 	"github.com/IBM-Blockchain/fabric-deployer/deployer/components/ca/api"
 	"github.com/IBM-Blockchain/fabric-deployer/deployer/components/common"
 	"github.com/IBM-Blockchain/fabric-deployer/deployer/util"
+	"github.com/IBM-Blockchain/fabric-deployer/offering"
 	current "github.com/IBM-Blockchain/fabric-operator/api/v1beta1"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -187,7 +188,10 @@ func (ca *CA) getEndpoints(originalCR *current.IBPCA, response *api.Response, st
 	if connectionProfile != nil {
 		if connectionProfile.Endpoints != nil {
 			endPoints := connectionProfile.Endpoints
-			updateEndpoints(endPoints, originalCR.Name, originalCR.Namespace, originalCR.Spec.Domain)
+			// Update endpoints for k8s clusters only
+			if ca.Kube.ClusterType(originalCR.Namespace) == offering.K8S {
+				updateEndpoints(endPoints, originalCR.Name, originalCR.Namespace, originalCR.Spec.Domain)
+			}
 			response.Endpoints = endPoints
 		} else {
 			ca.Logger.Warnf("Connection profile is missing fields endpoints")

--- a/packages/fabric-deployer/deployer/components/ca/mocks/kube.go
+++ b/packages/fabric-deployer/deployer/components/ca/mocks/kube.go
@@ -9,6 +9,17 @@ import (
 )
 
 type Kube struct {
+	ClusterTypeStub        func(string) string
+	clusterTypeMutex       sync.RWMutex
+	clusterTypeArgsForCall []struct {
+		arg1 string
+	}
+	clusterTypeReturns struct {
+		result1 string
+	}
+	clusterTypeReturnsOnCall map[int]struct {
+		result1 string
+	}
 	GetConfigMapStub        func(string, string) (*v1.ConfigMap, error)
 	getConfigMapMutex       sync.RWMutex
 	getConfigMapArgsForCall []struct {
@@ -67,6 +78,67 @@ type Kube struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *Kube) ClusterType(arg1 string) string {
+	fake.clusterTypeMutex.Lock()
+	ret, specificReturn := fake.clusterTypeReturnsOnCall[len(fake.clusterTypeArgsForCall)]
+	fake.clusterTypeArgsForCall = append(fake.clusterTypeArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.ClusterTypeStub
+	fakeReturns := fake.clusterTypeReturns
+	fake.recordInvocation("ClusterType", []interface{}{arg1})
+	fake.clusterTypeMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *Kube) ClusterTypeCallCount() int {
+	fake.clusterTypeMutex.RLock()
+	defer fake.clusterTypeMutex.RUnlock()
+	return len(fake.clusterTypeArgsForCall)
+}
+
+func (fake *Kube) ClusterTypeCalls(stub func(string) string) {
+	fake.clusterTypeMutex.Lock()
+	defer fake.clusterTypeMutex.Unlock()
+	fake.ClusterTypeStub = stub
+}
+
+func (fake *Kube) ClusterTypeArgsForCall(i int) string {
+	fake.clusterTypeMutex.RLock()
+	defer fake.clusterTypeMutex.RUnlock()
+	argsForCall := fake.clusterTypeArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *Kube) ClusterTypeReturns(result1 string) {
+	fake.clusterTypeMutex.Lock()
+	defer fake.clusterTypeMutex.Unlock()
+	fake.ClusterTypeStub = nil
+	fake.clusterTypeReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *Kube) ClusterTypeReturnsOnCall(i int, result1 string) {
+	fake.clusterTypeMutex.Lock()
+	defer fake.clusterTypeMutex.Unlock()
+	fake.ClusterTypeStub = nil
+	if fake.clusterTypeReturnsOnCall == nil {
+		fake.clusterTypeReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.clusterTypeReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
 }
 
 func (fake *Kube) GetConfigMap(arg1 string, arg2 string) (*v1.ConfigMap, error) {
@@ -332,6 +404,8 @@ func (fake *Kube) GetServiceReturnsOnCall(i int, result1 *v1.Service, result2 er
 func (fake *Kube) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.clusterTypeMutex.RLock()
+	defer fake.clusterTypeMutex.RUnlock()
 	fake.getConfigMapMutex.RLock()
 	defer fake.getConfigMapMutex.RUnlock()
 	fake.getPortMutex.RLock()

--- a/packages/fabric-deployer/deployer/components/orderer/get.go
+++ b/packages/fabric-deployer/deployer/components/orderer/get.go
@@ -25,6 +25,7 @@ import (
 	"github.com/IBM-Blockchain/fabric-deployer/deployer/components/common"
 	"github.com/IBM-Blockchain/fabric-deployer/deployer/components/orderer/api"
 	"github.com/IBM-Blockchain/fabric-deployer/deployer/util"
+	"github.com/IBM-Blockchain/fabric-deployer/offering"
 	current "github.com/IBM-Blockchain/fabric-operator/api/v1beta1"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -203,7 +204,10 @@ func (o *Orderer) getEndpoints(originalCR *current.IBPOrderer, response *api.Res
 	if connectionProfile != nil {
 		if connectionProfile.Endpoints != nil {
 			endPoints := connectionProfile.Endpoints
-			updateEndpoints(endPoints, originalCR.Name, originalCR.Namespace, originalCR.Spec.Domain)
+			// Update endpoints for k8s clusters only
+			if o.Kube.ClusterType(originalCR.Namespace) == offering.K8S {
+				updateEndpoints(endPoints, originalCR.Name, originalCR.Namespace, originalCR.Spec.Domain)
+			}
 			response.Endpoints = endPoints
 		} else {
 			o.Logger.Warnf("Connection profile is missing fields endpoints")

--- a/packages/fabric-deployer/deployer/components/orderer/mocks/kube.go
+++ b/packages/fabric-deployer/deployer/components/orderer/mocks/kube.go
@@ -9,6 +9,17 @@ import (
 )
 
 type Kube struct {
+	ClusterTypeStub        func(string) string
+	clusterTypeMutex       sync.RWMutex
+	clusterTypeArgsForCall []struct {
+		arg1 string
+	}
+	clusterTypeReturns struct {
+		result1 string
+	}
+	clusterTypeReturnsOnCall map[int]struct {
+		result1 string
+	}
 	DeleteAndCreateSecretStub        func(string, *v1.Secret) (*v1.Secret, error)
 	deleteAndCreateSecretMutex       sync.RWMutex
 	deleteAndCreateSecretArgsForCall []struct {
@@ -161,6 +172,67 @@ type Kube struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *Kube) ClusterType(arg1 string) string {
+	fake.clusterTypeMutex.Lock()
+	ret, specificReturn := fake.clusterTypeReturnsOnCall[len(fake.clusterTypeArgsForCall)]
+	fake.clusterTypeArgsForCall = append(fake.clusterTypeArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.ClusterTypeStub
+	fakeReturns := fake.clusterTypeReturns
+	fake.recordInvocation("ClusterType", []interface{}{arg1})
+	fake.clusterTypeMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *Kube) ClusterTypeCallCount() int {
+	fake.clusterTypeMutex.RLock()
+	defer fake.clusterTypeMutex.RUnlock()
+	return len(fake.clusterTypeArgsForCall)
+}
+
+func (fake *Kube) ClusterTypeCalls(stub func(string) string) {
+	fake.clusterTypeMutex.Lock()
+	defer fake.clusterTypeMutex.Unlock()
+	fake.ClusterTypeStub = stub
+}
+
+func (fake *Kube) ClusterTypeArgsForCall(i int) string {
+	fake.clusterTypeMutex.RLock()
+	defer fake.clusterTypeMutex.RUnlock()
+	argsForCall := fake.clusterTypeArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *Kube) ClusterTypeReturns(result1 string) {
+	fake.clusterTypeMutex.Lock()
+	defer fake.clusterTypeMutex.Unlock()
+	fake.ClusterTypeStub = nil
+	fake.clusterTypeReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *Kube) ClusterTypeReturnsOnCall(i int, result1 string) {
+	fake.clusterTypeMutex.Lock()
+	defer fake.clusterTypeMutex.Unlock()
+	fake.ClusterTypeStub = nil
+	if fake.clusterTypeReturnsOnCall == nil {
+		fake.clusterTypeReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.clusterTypeReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
 }
 
 func (fake *Kube) DeleteAndCreateSecret(arg1 string, arg2 *v1.Secret) (*v1.Secret, error) {
@@ -873,6 +945,8 @@ func (fake *Kube) UpdateSecretReturnsOnCall(i int, result1 *v1.Secret, result2 e
 func (fake *Kube) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.clusterTypeMutex.RLock()
+	defer fake.clusterTypeMutex.RUnlock()
 	fake.deleteAndCreateSecretMutex.RLock()
 	defer fake.deleteAndCreateSecretMutex.RUnlock()
 	fake.deleteDeploymentMutex.RLock()

--- a/packages/fabric-deployer/deployer/components/orderer/orderer.go
+++ b/packages/fabric-deployer/deployer/components/orderer/orderer.go
@@ -81,6 +81,7 @@ type Kube interface {
 	UpdateSecret(namespace, name, path string, data []byte) (*corev1.Secret, error)
 	DeleteDeployment(namespace string, depName string) error
 	GetPodsByLabel(namespace, name string) (*corev1.Pod, error)
+	ClusterType(namespace string) string
 }
 
 //go:generate counterfeiter -o mocks/ibp_client.go -fake-name IBPOperatorClient . IBPOperatorClient

--- a/packages/fabric-deployer/deployer/components/peer/get.go
+++ b/packages/fabric-deployer/deployer/components/peer/get.go
@@ -26,6 +26,7 @@ import (
 	"github.com/IBM-Blockchain/fabric-deployer/deployer/components/common"
 	"github.com/IBM-Blockchain/fabric-deployer/deployer/components/peer/api"
 	"github.com/IBM-Blockchain/fabric-deployer/deployer/util"
+	"github.com/IBM-Blockchain/fabric-deployer/offering"
 	current "github.com/IBM-Blockchain/fabric-operator/api/v1beta1"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -198,7 +199,10 @@ func (peer *Peer) getEndpoints(originalCR *current.IBPPeer, response *api.Respon
 	if connectionProfile != nil {
 		if connectionProfile.Endpoints != nil {
 			endPoints := connectionProfile.Endpoints
-			updateEndpoints(endPoints, originalCR.Name, originalCR.Namespace, originalCR.Spec.Domain)
+			// Update endpoints for k8s clusters only
+			if peer.Kube.ClusterType(originalCR.Namespace) == offering.K8S {
+				updateEndpoints(endPoints, originalCR.Name, originalCR.Namespace, originalCR.Spec.Domain)
+			}
 			response.Endpoints = endPoints
 		} else {
 			peer.Logger.Warnf("Connection profile is missing fields endpoints")

--- a/packages/fabric-deployer/deployer/components/peer/mocks/kube.go
+++ b/packages/fabric-deployer/deployer/components/peer/mocks/kube.go
@@ -9,6 +9,17 @@ import (
 )
 
 type Kube struct {
+	ClusterTypeStub        func(string) string
+	clusterTypeMutex       sync.RWMutex
+	clusterTypeArgsForCall []struct {
+		arg1 string
+	}
+	clusterTypeReturns struct {
+		result1 string
+	}
+	clusterTypeReturnsOnCall map[int]struct {
+		result1 string
+	}
 	CreateSecretStub        func(string, *v1.Secret) (*v1.Secret, error)
 	createSecretMutex       sync.RWMutex
 	createSecretArgsForCall []struct {
@@ -107,6 +118,67 @@ type Kube struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *Kube) ClusterType(arg1 string) string {
+	fake.clusterTypeMutex.Lock()
+	ret, specificReturn := fake.clusterTypeReturnsOnCall[len(fake.clusterTypeArgsForCall)]
+	fake.clusterTypeArgsForCall = append(fake.clusterTypeArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.ClusterTypeStub
+	fakeReturns := fake.clusterTypeReturns
+	fake.recordInvocation("ClusterType", []interface{}{arg1})
+	fake.clusterTypeMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *Kube) ClusterTypeCallCount() int {
+	fake.clusterTypeMutex.RLock()
+	defer fake.clusterTypeMutex.RUnlock()
+	return len(fake.clusterTypeArgsForCall)
+}
+
+func (fake *Kube) ClusterTypeCalls(stub func(string) string) {
+	fake.clusterTypeMutex.Lock()
+	defer fake.clusterTypeMutex.Unlock()
+	fake.ClusterTypeStub = stub
+}
+
+func (fake *Kube) ClusterTypeArgsForCall(i int) string {
+	fake.clusterTypeMutex.RLock()
+	defer fake.clusterTypeMutex.RUnlock()
+	argsForCall := fake.clusterTypeArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *Kube) ClusterTypeReturns(result1 string) {
+	fake.clusterTypeMutex.Lock()
+	defer fake.clusterTypeMutex.Unlock()
+	fake.ClusterTypeStub = nil
+	fake.clusterTypeReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *Kube) ClusterTypeReturnsOnCall(i int, result1 string) {
+	fake.clusterTypeMutex.Lock()
+	defer fake.clusterTypeMutex.Unlock()
+	fake.ClusterTypeStub = nil
+	if fake.clusterTypeReturnsOnCall == nil {
+		fake.clusterTypeReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.clusterTypeReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
 }
 
 func (fake *Kube) CreateSecret(arg1 string, arg2 *v1.Secret) (*v1.Secret, error) {
@@ -564,6 +636,8 @@ func (fake *Kube) GetServiceReturnsOnCall(i int, result1 *v1.Service, result2 er
 func (fake *Kube) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.clusterTypeMutex.RLock()
+	defer fake.clusterTypeMutex.RUnlock()
 	fake.createSecretMutex.RLock()
 	defer fake.createSecretMutex.RUnlock()
 	fake.deleteAndCreateSecretMutex.RLock()

--- a/packages/fabric-deployer/deployer/components/peer/peer.go
+++ b/packages/fabric-deployer/deployer/components/peer/peer.go
@@ -76,6 +76,7 @@ type Kube interface {
 	GetPort(namespace, name string) (int32, error)
 	GetPorts(namespace, name string) ([]corev1.ServicePort, error)
 	CreateSecret(namespace string, secret *corev1.Secret) (*corev1.Secret, error)
+	ClusterType(namespace string) string
 }
 
 //go:generate counterfeiter -o mocks/ibp_client.go -fake-name IBPOperatorClient . IBPOperatorClient

--- a/packages/fabric-deployer/deployer/deployer.go
+++ b/packages/fabric-deployer/deployer/deployer.go
@@ -236,6 +236,9 @@ func (d *Deployer) registerEndpoints() {
 	// k8s
 	r.Get("/api/v3/instance/{serviceInstanceID}/k8s/cluster/version", d.K8sVersionEndpoint())
 
+	// cluster
+	r.Get("/api/v3/instance/{serviceInstanceID}/cluster/type", d.ClusterTypeEndpoint())
+
 	// mustgather
 	r.Get("/api/v3/instance/{serviceInstanceID}/mustgather", d.GetMustgatherEndpoint())
 	r.Post("/api/v3/instance/{serviceInstanceID}/mustgather", d.StartMustgatherEndpoint())
@@ -299,6 +302,12 @@ func (d *Deployer) healthCheck(w http.ResponseWriter, r *http.Request) {
 // getting kuberenetes cluster version
 func (d *Deployer) K8sVersionEndpoint() func(http.ResponseWriter, *http.Request) {
 	return NewEndpoint(d.ClusterVersionHandler, d.LocalConfig.Logger).ServeHTTP
+}
+
+// ClusterTypeEndpoint returns an endpoint type that is responsible for handling
+// getting the type of the cluster kubernetes or openshift
+func (d *Deployer) ClusterTypeEndpoint() func(http.ResponseWriter, *http.Request) {
+	return NewEndpoint(d.ClusterTypeHandler, d.LocalConfig.Logger).ServeHTTP
 }
 
 func (d *Deployer) VersionEndpoint() func(http.ResponseWriter, *http.Request) {
@@ -607,4 +616,9 @@ func (d *Deployer) StartMustgather(w http.ResponseWriter, r *http.Request) (inte
 func (d *Deployer) StopMustgather(w http.ResponseWriter, r *http.Request) (interface{}, int, error) {
 	err := d.Mustgather.Delete()
 	return nil, 200, err
+}
+
+// ClusterTypeHandler will handle returning the clustertype kubernetes cluster version
+func (d *Deployer) ClusterTypeHandler(w http.ResponseWriter, r *http.Request) (interface{}, int, error) {
+	return d.K8SClient.ClusterType(d.Config.Namespace), 0, nil
 }

--- a/packages/fabric-deployer/deployer/kube/kube.go
+++ b/packages/fabric-deployer/deployer/kube/kube.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/IBM-Blockchain/fabric-deployer/offering"
 	"github.com/pkg/errors"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -206,4 +207,15 @@ func (k *Kube) DeleteAndCreatePod(namespace string, podSpec *apiv1.Pod, label st
 	}
 
 	return pod, nil
+}
+
+func (k *Kube) ClusterType(namespace string) string {
+	var clusterType string
+	_, err := k.GetConfigMap(namespace, "openshift-service-ca.crt")
+	if err != nil {
+		clusterType = strings.ToLower(string(offering.K8S))
+	} else {
+		clusterType = strings.ToLower(string(offering.OPENSHIFT))
+	}
+	return clusterType
 }


### PR DESCRIPTION
#### Type of change

- Bug fix
- Improvement

#### Description
* A new endpoint `/api/v3/instance/{serviceInstanceID}/cluster/type` to determine if the cluster is ocp or k8s 
* Added a fix to override endpoints for k8s only and unchange ocp endpoints

