### PR TITLE
format migrated url correctly if standard port

### DIFF
--- a/packages/athena/libs/migration_lib.js
+++ b/packages/athena/libs/migration_lib.js
@@ -589,6 +589,16 @@ module.exports = function (logger, ev, t) {
 					return cb({ statusCode: 500, err: 'settings doc is missing' }, doc);	// this should be impossible
 				}
 
+				// format/validate the new console url
+				const parts = t.misc.break_up_url(value);
+				if (parts && parts.hostname) {
+					let new_console_url = parts.protocol + '//' + parts.hostname;
+					if (Number(parts.port) !== 443 && Number(parts.port) !== 80) {		// if a non-standard port is used add it, else don't add the port
+						new_console_url += ':' + parts.port;
+					}
+					value = new_console_url;
+				}
+
 				doc.migrated_console_url = value;
 				ev.MIGRATED_CONSOLE_URL = value;
 


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
Formats the migrated console url correctly when standard ports like 443 or 80 are used. This fixes logic downstream that attempts to match against this url value.

