### PR TITLE
disable read only state in newly migrated consoles

### DIFF
--- a/packages/athena/libs/migration_lib.js
+++ b/packages/athena/libs/migration_lib.js
@@ -1283,6 +1283,7 @@ module.exports = function (logger, ev, t) {
 
 						if (doc.feature_flags) {
 							doc.feature_flags.migration_enabled = false;
+							doc.feature_flags.read_only_enabled = false;
 						}
 
 						// create the user login for the new console


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
Newly migrated consoles should not be in the read-only state.

