### PR TITLE
fix password str validation on a dry-run request

### DIFF
--- a/packages/athena/libs/jupiter_lib.js
+++ b/packages/athena/libs/jupiter_lib.js
@@ -92,6 +92,10 @@ module.exports = function (logger, ev, t) {
 				timeout: ev.DEPLOYER_TIMEOUT,
 			};
 
+			// debug code
+			//return cb({ statusCode: 500 });
+			//return cb({ statusCode: 200, response: { url: 'http://localhost:3000' } });
+
 			t.request(options, (err, resp) => {
 				let response = resp ? resp.body : null;
 				let code = t.ot_misc.get_code(resp);
@@ -111,14 +115,6 @@ module.exports = function (logger, ev, t) {
 					return cb({ statusCode: code, response: response });
 				}
 			});
-
-			// debug code
-			/*setTimeout(() => {
-				console.log('[simulation] sim jupiter response for req:', options);
-				//return cb({ statusCode: 500, response: { message: 'hello there' } });
-				//return cb({ statusCode: 500 });
-				return cb({ statusCode: 200, response: { url: 'http://localhost:3000' } });
-			}, 2000);*/
 		}
 
 		function strip_account_prefix(account_id) {

--- a/packages/athena/libs/permissions_lib.js
+++ b/packages/athena/libs/permissions_lib.js
@@ -465,7 +465,7 @@ module.exports = function (logger, ev, t) {
 					// validate the new password
 					const uuid = t.middleware.getUuid(req);
 					const email = find_users_email(uuid, settings_doc);
-					if (!email) {
+					if (!email && !req._dry_run) {
 						input_errors.push('user by uuid does not exist: ' + encodeURI(uuid));
 					} else {
 						req.body.desired_pass = typeof req.body.desired_pass === 'string' ? req.body.desired_pass.trim() : '';	// protect user from whitespace


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix
- 
#### Description
Fixes password strength validation api if the request was a dry-run and the user does not exist. User does not need to exist for dry-run checks.

