### PR TITLE
reconnect to couchdb _changes api periodically ++

### DIFF
--- a/packages/athena/libs/migration_lib.js
+++ b/packages/athena/libs/migration_lib.js
@@ -260,6 +260,7 @@ module.exports = function (logger, ev, t) {
 						logger.error('[migration lib] cannot edit settings doc to clear migration status:', err_writeDoc);
 						return cb({ statusCode: 500, msg: 'could not update settings doc to clear migration status', details: err_writeDoc }, null);
 					} else {
+						t.pillow.reconnect();					// make sure the couchdb stream is working by simply reconnecting now
 						return cb(null, settings_doc);
 					}
 				});


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
- lets athena safely periodically reconnect to the couchdb _changes api
   - it will now reconnect daily
- migration will now reconnect the _changes api when migration has started to ensure the api is alive and well
- ties into more request events to let the couchdb _changes api reconnect when things go wrong
  - previously only the events `error` and `end` where used to reconnect, we now use `error`, `end`, `timeout`, `abort`, `close`

