### PR TITLE
don't return sso error in response on failed login

### DIFF
--- a/packages/athena/libs/authentication_lib.js
+++ b/packages/athena/libs/authentication_lib.js
@@ -63,10 +63,12 @@ module.exports = function (logger, ev, t) {
 
 					if (e != null) {
 						logger.error('[passport] error:', typeof e, e);
+
+						// don't reply with the iam error details to appease the pen-testers
 						if (url_parts && url_parts.query && url_parts.query.code) {
-							res.status(400).json({ oauth_error: 'could not exchange oauth code for a token', details: e });	// avoid redirect loop, show error
+							res.status(400).json({ oauth_error: 'could not exchange oauth code for a token' });	// avoid redirect loop, show error
 						} else {
-							res.status(500).json({ oauth_error: 'oauth flow encountered an error', details: e });	// avoid redirect loop, show error
+							res.status(500).json({ oauth_error: 'oauth flow encountered an error' });	// avoid redirect loop, show error
 						}
 					} else {
 						req.session.passport_profile = profile;			// store the passport data (including iam actions)


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement (improvement to code, performance, etc)

#### Description
Hides the details of a sso login failure from surfacing on the UI. the error is still logged. this was recommended by our pentesters.

