### PR TITLE
compress console database backups and use fs

### DIFF
--- a/dictionary_blockchain.txt
+++ b/dictionary_blockchain.txt
@@ -349,3 +349,10 @@ multiregion
 checkmark
 unparseable
 preqs
+pentesters
+idaas
+sess
+ldapauth
+openidconnect
+soidc
+channelless

--- a/packages/athena/app.js
+++ b/packages/athena/app.js
@@ -30,6 +30,7 @@ const tools = {										// stateless util libs should go here, ~8% faster start
 	NodeCache: require('node-cache'),
 	winston: require('winston'),
 	selfsigned: require('selfsigned'),
+	zlib: require('zlib'),
 };
 
 const bodyParser = require('body-parser');

--- a/packages/athena/package-lock.json
+++ b/packages/athena/package-lock.json
@@ -33,7 +33,8 @@
 				"selfsigned": "^1.10.8",
 				"uuid": "3.3.*",
 				"winston": "2.4.*",
-				"ws": "7.4.*"
+				"ws": "7.4.*",
+				"zlib": "^1.0.5"
 			},
 			"devDependencies": {
 				"chai": "^4.1.2",
@@ -1271,20 +1272,6 @@
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^6.2.0"
-			}
-		},
-		"node_modules/cliui/node_modules/string-width": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-			"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-			"dev": true,
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/clone": {
@@ -5436,20 +5423,6 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
-		"node_modules/wrap-ansi/node_modules/string-width": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-			"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-			"dev": true,
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -5614,6 +5587,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zlib": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/zlib/-/zlib-1.0.5.tgz",
+			"integrity": "sha512-40fpE2II+Cd3k8HWTWONfeKE2jL+P42iWJ1zzps5W51qcTsOUKM5Q5m2PFb0CLxlmFAaUuUdJGc3OfZy947v0w==",
+			"hasInstallScript": true,
+			"engines": {
+				"node": ">=0.2.0"
 			}
 		}
 	},
@@ -6646,19 +6628,6 @@
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^6.2.0"
-			},
-			"dependencies": {
-				"string-width": {
-					"version": "4.2.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
-				}
 			}
 		},
 		"clone": {
@@ -9812,17 +9781,6 @@
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
-				},
-				"string-width": {
-					"version": "4.2.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
 				}
 			}
 		},
@@ -9945,6 +9903,11 @@
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"dev": true
+		},
+		"zlib": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/zlib/-/zlib-1.0.5.tgz",
+			"integrity": "sha512-40fpE2II+Cd3k8HWTWONfeKE2jL+P42iWJ1zzps5W51qcTsOUKM5Q5m2PFb0CLxlmFAaUuUdJGc3OfZy947v0w=="
 		}
 	}
 }

--- a/packages/athena/package.json
+++ b/packages/athena/package.json
@@ -49,7 +49,8 @@
 		"selfsigned": "^1.10.8",
 		"uuid": "3.3.*",
 		"winston": "2.4.*",
-		"ws": "7.4.*"
+		"ws": "7.4.*",
+		"zlib": "^1.0.5"
 	},
 	"devDependencies": {
 		"chai": "^4.1.2",

--- a/packages/athena/public/releaseNotes.json
+++ b/packages/athena/public/releaseNotes.json
@@ -1,5 +1,19 @@
 [
 	{
+		"version": "1.0.5-6",
+		"date": "04 April 2023",
+		"description": [
+			{
+				"title": "Bug & security fixes",
+				"details": "Miscellaneous fixes & dependency updates."
+			},
+			{
+				"title": "Node v18",
+				"details": "Updated to use Node v18.5"
+			}
+		]
+	},
+	{
 		"version": "1.0.5-3",
 		"date": "15 March 2023",
 		"description": [


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement

#### Description

- console database backups will be temporary stored to the filesystem to avoid cloudant size limits
- console database backups will be compressed to minimize transfer sizes during migration
