### PR TITLE
tidy up console restart apis

### DIFF
--- a/packages/athena/libs/ot_misc.js
+++ b/packages/athena/libs/ot_misc.js
@@ -71,9 +71,9 @@ module.exports = function (logger, t) {
 		const LOG_PATH = 'logs/athena_restart.log';							// must match what is in server_watcher.js
 		const restart_path = t.path.join(__dirname, '../' + LOG_PATH);
 
-		logger.debug('---------------------------- restart ----------------------------');
-		logger.info('Restarting Athena - imminent');
-		logger.debug('---------------------------- restart ----------------------------');
+		logger.silly('---------------------------- restart ----------------------------');
+		logger.info('Restarting Athena "' + process.env.ATHENA_ID + '" - imminent');
+		logger.silly('---------------------------- restart ----------------------------');
 
 		const message = date + ' - restarted via restart_athena() - uuid: ' + uuid;
 		const orig_file = t.fs.existsSync(restart_path) ? t.fs.readFileSync(restart_path) : '';

--- a/packages/athena/routes/other_apis.js
+++ b/packages/athena/routes/other_apis.js
@@ -93,23 +93,28 @@ module.exports = function (logger, ev, t) {
 	// Restart Athena
 	//--------------------------------------------------
 	app.post('/api/v[123]/restart', t.middleware.verify_restart_action_session, function (req, res) {
-		restart(req, res);
+		restart_via_pillow(req, res);
 	});
 	app.post('/ak/api/v[123]/restart', t.middleware.verify_restart_action_ak, function (req, res) {
-		restart(req, res);
+		restart_via_pillow(req, res);
 	});
 	app.get('/api/v[3]/restart/force', t.middleware.verify_restart_action_session, function (req, res) {
-		res.status(200).json({ message: 'you got it' });
-		t.ot_misc.restart_athena(t.middleware.getUuid(req));						// restart this instance right now, no db -> pillow talk
+		restart_via_fs(req, res);
 	});
 	app.post('/ak/api/v[123]/restart/force', t.middleware.verify_restart_action_ak, function (req, res) {
-		res.status(200).json({ message: 'you got it' });
-		t.ot_misc.restart_athena(t.middleware.getUuid(req));						// restart this instance right now, no db -> pillow talk
+		restart_via_fs(req, res);
+	});
+	app.get('/api/v[123]/restart/force/hard', t.middleware.verify_restart_action_session, function (req, res) {
+		restart_hard(req, res);
+	});
+	app.post('/ak/api/v[123]/restart/force/hard', t.middleware.verify_restart_action_ak, function (req, res) {
+		restart_hard(req, res);
 	});
 
-	function restart(req, res) {
+	// restart using pillow talk which in turn uses the file system watcher
+	// will restart ALL consoles
+	function restart_via_pillow(req, res) {
 		res.status(200).json({ message: 'restarting - give me 5-30 seconds' });		// respond first, else we will restart w/o responding
-
 		const msg = {
 			message_type: 'restart',
 			message: 'restarting application via restart api',
@@ -117,6 +122,28 @@ module.exports = function (logger, ev, t) {
 			uuid: t.middleware.getUuid(req),
 		};
 		t.pillow.broadcast(msg);
+	}
+
+	// restart via the file system watcher only
+	// only restarts this console (which is the process that got the http request)
+	function restart_via_fs(req, res) {
+		res.status(200).json({ message: 'you got it' });
+		logger.warn('[restart] restarting athena from a force restart api');
+		setTimeout(() => {
+			t.ot_misc.restart_athena(t.middleware.getUuid(req));				// restart this instance right now, no db -> pillow talk
+		}, 500);
+	}
+
+	// restart by killing self and letting k8s sch a new pod
+	// only restarts this console (which is the process that got the http request)
+	function restart_hard(req, res) {
+		res.status(200).json({ message: 'you got it, killing self :(' });
+		logger.silly('---------------------------- restart ----------------------------');
+		logger.info('Restarting Athena "' + process.env.ATHENA_ID + '" - restarting the hard way, see you next time');
+		logger.silly('---------------------------- restart ----------------------------');
+		setTimeout(() => {
+			process.exit();
+		}, 500);
 	}
 
 	//--------------------------------------------------


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement (improvement to code, performance, etc)

#### Description
- console restart apis will now log the process id that is restarting
- added restart api that will kill the process (which kills the pod) `ak/api/v[123]/restart/force/hard`

