### PR TITLE
make couchdb url use ipv4 and not ipv6

### DIFF
--- a/packages/athena/libs/couchdb.js
+++ b/packages/athena/libs/couchdb.js
@@ -18,31 +18,9 @@
 //=======================================================================================================
 module.exports = (logger, t, DB_CONNECTION_STRING) => {
 	const couch = {};
-	const couch_url = build_couch_base_url(DB_CONNECTION_STRING);
-
-	// build the url to connect to couch
-	function build_couch_base_url(dbConnectionString) {
-		const parts = t.url.parse(dbConnectionString);
-		if (!parts) {
-			logger.error('[couchdb] - Could not parse dbConnectionString...', dbConnectionString);
-			return null;
-		} else {
-			if (!parts.protocol) {
-				parts.protocol = 'http:';				// no protocol, defaults to http
-			}
-			if (parts.protocol === 'https:') {
-				if (!parts.port) {						// no port for https, defaults 443
-					parts.port = 443;
-				}
-			} else {									// no port for http, defaults 80
-				if (!parts.port) {
-					parts.port = 80;
-				}
-			}
-			const auth_str = (parts.auth) ? parts.auth + '@' : '';	// defaults to no auth
-
-			return parts.protocol + '//' + auth_str + parts.hostname + ':' + parts.port;
-		}
+	const couch_url = t.root_misc.format_url(DB_CONNECTION_STRING, { default: 'http:', useIpv4: true });
+	if (!couch_url) {
+		logger.error('[couchdb] - Could not parse DB_CONNECTION_STRING, athena cannot start without a connection to the database...');
 	}
 
 	// wrapper function

--- a/packages/athena/libs/ot_misc.js
+++ b/packages/athena/libs/ot_misc.js
@@ -218,7 +218,7 @@ module.exports = function (logger, t) {
 			}
 		}
 		settings.CONFIGTXLATOR_TIMEOUT = -1;
-		return settings.CONFIGTXLATOR_URL_ORIGINAL;
+		return t.misc.format_url(settings.CONFIGTXLATOR_URL_ORIGINAL, { useIpv4: true });
 	};
 
 	//-------------------------------------------------------------

--- a/packages/athena/libs/other_apis_lib.js
+++ b/packages/athena/libs/other_apis_lib.js
@@ -169,6 +169,7 @@ module.exports = function (logger, ev, t) {
 			CONFIGTXLATOR_URL_ORIGINAL: ev.CONFIGTXLATOR_URL_ORIGINAL || '?',
 			COOKIE_NAME: ev.COOKIE_NAME || '?',
 			MIGRATION_API_KEY: ev.MIGRATION_API_KEY,			// for debug
+			DB_CONNECTION_STRING: t.misc.redact_basic_auth(ev.DB_CONNECTION_STRING),	// for debug
 		};
 		return t.misc.sortItOut(ret);
 	};

--- a/packages/athena/libs/root_misc.js
+++ b/packages/athena/libs/root_misc.js
@@ -38,7 +38,11 @@ module.exports = function (logger) {
 	// ------------------------------------------
 	exports.break_up_url = function (url, opts) {
 		if (url && typeof url === 'string' && !url.includes('://')) {			// if no protocol, assume https
-			url = 'https://' + url;												// append https so we can parse it
+			if (opts && opts.default && typeof opts.default === 'string' && !parts.protocol) {
+				url = opts.default + '//' + url;								// default protocol was passed in
+			} else {
+				url = 'https://' + url;											// append https so we can parse it
+			}
 		}
 
 		const parts = typeof url === 'string' ? __url.parse(url) : null;

--- a/packages/athena/libs/root_misc.js
+++ b/packages/athena/libs/root_misc.js
@@ -1,0 +1,133 @@
+/*
+ * Copyright contributors to the Hyperledger Fabric Operations Console project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+//------------------------------------------------------------
+// root_misc.js - common/general miscellaneous functions that are INDEPENDENT (no tools object)
+//------------------------------------------------------------
+
+module.exports = function (logger) {
+	const exports = {};
+	const __url = require('url');
+
+	// ------------------------------------------
+	// return the hostname from a url
+	// ------------------------------------------
+	exports.get_host = function (url) {
+		const parts = exports.break_up_url(url);
+		if (!parts) {
+			return null;					// error is logged elsewhere
+		} else {
+			return parts.hostname;
+		}
+	};
+
+	// ------------------------------------------
+	// break up url in proto, basic auth, hostname, port, etc
+	// ------------------------------------------
+	exports.break_up_url = function (url, opts) {
+		if (url && typeof url === 'string' && !url.includes('://')) {			// if no protocol, assume https
+			url = 'https://' + url;												// append https so we can parse it
+		}
+
+		const parts = typeof url === 'string' ? __url.parse(url) : null;
+		if (!parts || !parts.hostname) {
+			logger.error('[misc] cannot parse url:', encodeURI(url));
+			return null;
+		} else {
+			let protocol = parts.protocol ? parts.protocol : 'https:';			// default protocol is https
+			if (opts && opts.default && typeof opts.default === 'string' && !parts.protocol) {
+				protocol = opts.default;										// default protocol was passed in
+			}
+			if (!parts.port) {
+				parts.port = protocol === 'https:' ? '443' : '80';				// match default ports to protocol
+			}
+			parts.auth_str = parts.auth ? parts.auth + '@' : '';				// defaults to no auth
+
+			return parts;
+		}
+	};
+
+	// ------------------------------------------
+	// parse url return proto + :basic_auth? + hostname + port
+	// ------------------------------------------
+	exports.format_url = function (url, opts) {
+		const parts = exports.break_up_url(url, opts);
+		if (!parts || !parts.hostname) {
+			return null;					// error is logged elsewhere
+		} else {
+			if (opts && opts.useIpv4 === true) {
+				parts.hostname = exports.fix_localhost(parts.hostname);
+			}
+			return parts.protocol + '//' + parts.auth_str + parts.hostname + ':' + parts.port;
+		}
+	};
+
+	// ------------------------------------------
+	// redact basic auth in url
+	// ------------------------------------------
+	exports.redact_basic_auth = function (url) {
+		const parts = exports.break_up_url(url);
+		if (!parts || !parts.hostname) {
+			return null;				// error is logged elsewhere
+		} else {
+			return parts.protocol + '//' + parts.hostname + ':' + parts.port;
+		}
+	};
+
+	// ------------------------------------------
+	// return hostname + port from url (no protocol, no basic auth)
+	// ------------------------------------------
+	exports.fmt_url = function (url) {
+		const parts = exports.break_up_url(url);
+		if (!parts || !parts.hostname) {
+			return null;				// error is logged elsewhere
+		} else {
+			return parts.hostname + ':' + parts.port;
+		}
+	};
+
+	// ------------------------------------------
+	// parse query parameter as array of strings
+	// ------------------------------------------
+	exports.fmt_arr_of_strings_query_param = function (req, field_name) {
+		let ret = null;
+		if (field_name && req && req.query && req.query[field_name]) {
+			try {
+				ret = [];
+				req.query[field_name] = req.query[field_name].replace(/'/g, '"');	// allow user to input single quotes, double quotes preferred
+				if (req.query[field_name]) {
+					ret = JSON.parse(decodeURIComponent(req.query[field_name]));
+				}
+			} catch (e) {
+				logger.error('[misc] unable to parse query param', field_name, e);
+				ret = null;
+			}
+		}
+		return ret;
+	};
+
+	// ---------------------------------------------
+	// node 18 will translate "localhost" to ""::1" which is a IPv6 format, if the destination is not listening on IPv6 the connection will fail!
+	// we need to switch "localhost" to the ip version which will keep the connection as IPv4.
+	// ---------------------------------------------
+	exports.fix_localhost = function (url_str) {
+		if (url_str && typeof url_str === 'string' && url_str.includes('localhost')) {
+			url_str = url_str.replace('localhost', '127.0.0.1');
+		}
+		return url_str;
+	};
+
+	return exports;
+};

--- a/packages/athena/libs/root_misc.js
+++ b/packages/athena/libs/root_misc.js
@@ -38,7 +38,7 @@ module.exports = function (logger) {
 	// ------------------------------------------
 	exports.break_up_url = function (url, opts) {
 		if (url && typeof url === 'string' && !url.includes('://')) {			// if no protocol, assume https
-			if (opts && opts.default && typeof opts.default === 'string' && !parts.protocol) {
+			if (opts && opts.default && typeof opts.default === 'string') {
 				url = opts.default + '//' + url;								// default protocol was passed in
 			} else {
 				url = 'https://' + url;											// append https so we can parse it

--- a/packages/athena/libs/webhook_lib.js
+++ b/packages/athena/libs/webhook_lib.js
@@ -488,7 +488,7 @@ module.exports = function (logger, ev, t) {
 	// ------------------------------------------
 	exports.fetch_webhook_status = function (tx_id, cb) {
 		const opts = {
-			baseUrl: encodeURI(t.misc.format_url(ev.DEPLOYER_URL)),						// url to deployer
+			baseUrl: encodeURI(t.misc.format_url(ev.DEPLOYER_URL, { useIpv4: true })),						// url to deployer
 			url: encodeURI('/api/v3/txs/' + tx_id),
 			method: 'GET',
 			headers: { 'Accept': 'application/json' }

--- a/packages/athena/test/test-suites/common-test-framework.js
+++ b/packages/athena/test/test-suites/common-test-framework.js
@@ -285,6 +285,7 @@ if (!tools.fs.existsSync(config_file_location)) {
 // ---------------
 // Add other libs to tools
 // ---------------
+tools.root_misc = require('../../libs/root_misc.js')(logger);
 tools.wss1_athena = {
 	broadcast: function () { }
 };

--- a/packages/athena/test/test-suites/lib/couchdb.test.js
+++ b/packages/athena/test/test-suites/lib/couchdb.test.js
@@ -39,6 +39,7 @@ const tools = {										// stateless util libs should go here
 	async: require('async'),
 	request: require('request'),
 };
+tools.root_misc = require('../../../libs/root_misc.js')(logger);
 tools.misc = require('../../../libs/misc.js')(logger, tools);
 
 let couch;


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
With node 18, values of `localhost` are interpreted as their IPv6 equivalent of `::1`, however our couchdb containers are not listening on `::1`, they only work with IPv4. This PR replaces `localhost` on outgoing destinations with `127.0.0.1` to keep things as IPv4.

This fixes database connecting issues (with certain couchdb configurations) seen since build `1.0.5-3`.

