### PR TITLE
fix logic on orderer modals, speed improvement

### DIFF
--- a/packages/apollo/src/components/Log/Logger.js
+++ b/packages/apollo/src/components/Log/Logger.js
@@ -34,7 +34,7 @@ class Logger {
 
 	debugMessage(level, message) {
 		if (window.log) {
-			window.log[level](this.source ? this.source + ':' + message : message);
+			window.log[level](this.source ? this.source + ': ' + message : message);
 		}
 
 		const debugLevel = level === 'log' ? 'debug' : level;

--- a/packages/apollo/src/components/OrdererDetails/OrdererDetails.js
+++ b/packages/apollo/src/components/OrdererDetails/OrdererDetails.js
@@ -1007,7 +1007,7 @@ class OrdererDetails extends Component {
 				channelId: orderer.system_channel || OrdererRestApi.systemChannel,
 				configtxlator_url: options.configtxlator_url,
 			};
-			const block = await OrdererRestApi.getChannelConfigBlock(block_options);
+			const block = await OrdererRestApi.getChannelConfigBlock(block_options, orderer);
 
 			const b64_config_block = window.stitch.uint8ArrayToBase64(block);
 			await OrdererRestApi.uploadConfigBlock(options.ordererId, b64_config_block);
@@ -1051,13 +1051,13 @@ class OrdererDetails extends Component {
 		return quickAction;
 	};
 
-	async getChannelConfig(channelId) {
+	async getChannelConfigWrap(channelId, orderer) {
 		const options = {
 			ordererId: this.props.match.params.ordererId,
 			configtxlator_url: this.props.configtxlator_url,
 			channelId: channelId,
 		};
-		let block = await OrdererRestApi.getChannelConfigBlock(options);
+		let block = await OrdererRestApi.getChannelConfigBlock(options, orderer);
 		const _block_binary2json = promisify(ChannelApi._block_binary2json);
 		const resp = await _block_binary2json(block, options.configtxlator_url);
 		return resp.data.data[0].payload.data;
@@ -1067,7 +1067,7 @@ class OrdererDetails extends Component {
 		OrdererRestApi.getOrdererDetails(this.props.match.params.ordererId, false)
 			.then(orderer => {
 				let channelId = this.props.match.params.channelId || orderer.system_channel || OrdererRestApi.systemChannel;
-				this.getChannelConfig(channelId).then(debug_block => {
+				this.getChannelConfigWrap(channelId, orderer).then(debug_block => {
 					Helper.openJSONBlob(debug_block);
 				});
 			})

--- a/packages/apollo/src/rest/NodeRestApi.js
+++ b/packages/apollo/src/rest/NodeRestApi.js
@@ -208,6 +208,7 @@ class NodeRestApi {
 			nodes = await NodeRestApi.getAllNodes(skip_cache);
 			// NOTE: the nodes list is already sorted at this point
 		} catch (error) {
+			Log.error('caught error getting all nodes:', error);
 			if (error.statusCode === 404 && error.msg === 'no components exist') {
 				nodes = [];
 			} else {
@@ -219,7 +220,7 @@ class NodeRestApi {
 				throw error;
 			}
 		}
-		const filteredNodes = type ? nodes.filter(n => n.type === type) : nodes;
+		const filteredNodes = type ? nodes.filter(n => n && n.type === type) : nodes;
 		return this.formatNodes(filteredNodes);
 	}
 
@@ -258,7 +259,9 @@ class NodeRestApi {
 		const clusters = {};
 		const ff = await SettingsApi.getFeatureFlags();
 		const patch_1_4to2_x_enabled = ff.patch_1_4to2_x_enabled;
+
 		filteredNodes.forEach(originalNode => {
+
 			// Get santitized copy of node
 			const node = NodeRestApi.sanitizeNode(originalNode);
 			if (node.backend_addr) {
@@ -305,6 +308,7 @@ class NodeRestApi {
 				}
 			}
 			node.isUpgradeAvailable = isUpgradeAvailable;
+
 			// Check if this is a RAFT node that is part of an ordering service cluster
 			if (node.cluster_id) {
 				let cluster = clusters[node.cluster_id];
@@ -642,6 +646,8 @@ class NodeRestApi {
 				} catch (err) {
 					// do nothing
 				}
+				return node;
+			} else {
 				return node;
 			}
 		}

--- a/packages/athena/public/releaseNotes.json
+++ b/packages/athena/public/releaseNotes.json
@@ -1,7 +1,7 @@
 [
 	{
-		"version": "1.0.5-8",
-		"date": "05 April 2023",
+		"version": "1.0.5-11",
+		"date": "11 April 2023",
 		"description": [
 			{
 				"title": "Bug & security fixes",
@@ -10,6 +10,10 @@
 			{
 				"title": "Node v18",
 				"details": "Updated to use Node v18.5"
+			},
+			{
+				"title": "Performance Improvements",
+				"details": "A few pages should load their content faster, especially on Orderer related pages/modals."
 			}
 		]
 	},

--- a/packages/stitch/src/libs/proto_handlers/block_pb_lib.ts
+++ b/packages/stitch/src/libs/proto_handlers/block_pb_lib.ts
@@ -415,7 +415,7 @@ function decode_common_envelope(b_envelope: Uint8Array) {
 		const signature_header = decode_signature_header(p_signature_header);
 
 		const data = decode_payload_data(b_data2, channel_header.type);
-		logger.debug('[stitch] data?', data);
+		//logger.debug('[stitch] data?', data);
 
 		return {
 			envelope: {
@@ -597,7 +597,7 @@ function decode_payload_data(b_data: any, type: number) {
 				const b_channel_header = p_header.getChannelHeader();
 				const p_channel_header = Common_ChannelHeader.deserializeBinary(<Uint8Array>b_channel_header);
 				channel_header = p_channel_header.toObject();
-				logger.debug('[stitch] channel_header?', channel_header);
+				//logger.debug('[stitch] channel_header?', channel_header);
 
 				const p_signature_header = p_header.getSignatureHeader();
 				signature_header = decode_signature_header(p_signature_header);

--- a/packages/stitch/src/libs/proto_handlers/proposal_pb_lib.ts
+++ b/packages/stitch/src/libs/proto_handlers/proposal_pb_lib.ts
@@ -24,7 +24,7 @@ import { Header as Common_Header } from '../../protoc/output/common/common_pb';
 import { ProposalResponse as ProposalResponse_ProposalResponse } from '../../protoc/output/peer/proposal_response_pb';
 
 // Libs built by us
-import { arrToUint8Array, generate_tx_id, logger, pp, load_pb } from '../misc';
+import { arrToUint8Array, generate_tx_id, logger, /*pp,*/ load_pb } from '../misc';
 import { build_nonce, scSign, decode_b64_pem, pem2DER } from '../crypto_misc';
 import { validate_proposal_options } from '../validation';
 import { TransactionLib } from './transaction_pb_lib';
@@ -321,7 +321,7 @@ export class ProposalLib {
 			};
 			const p_payload = commonLib.p_build_payload(p_opts);
 
-			logger.debug('p_payload', pp(p_payload.toObject()));
+			//logger.debug('p_payload', pp(p_payload.toObject()));
 			//logger.debug('p_payload seek as hex', uint8ArrayToHexStr(p_payload.serializeBinary()));
 
 			// 7. Build singed proposal
@@ -330,7 +330,7 @@ export class ProposalLib {
 				p_proposal: p_payload,
 			};
 			this.p_build_signed_proposal(sp_opts, (_: any, p_signed_proposal: any) => {
-				logger.debug('p_signed_proposal seek', p_signed_proposal ? p_signed_proposal.toObject() : null);
+				//logger.debug('p_signed_proposal seek', p_signed_proposal ? p_signed_proposal.toObject() : null);
 				return cb(null, p_signed_proposal);
 			});
 		});
@@ -460,7 +460,7 @@ export class ProposalLib {
 			};
 			const p_payload = (new CommonLib).p_build_payload(p_opts);
 
-			logger.debug('p_payload?', pp(p_payload.toObject()));
+			//logger.debug('p_payload?', pp(p_payload.toObject()));
 			//logger.debug('p_payload tx as hex', uint8ArrayToHexStr(p_payload.serializeBinary()));
 
 			// 7. Build singed proposal
@@ -546,7 +546,7 @@ export class ProposalLib {
 					b_data: b_config_update_envelope,
 				};
 				const p_payload = commonLib.p_build_payload(p_opts);
-				logger.debug('p_payload', pp(p_payload.toObject()));
+				//logger.debug('p_payload', pp(p_payload.toObject()));
 				//logger.debug('p_payload seek as hex', uint8ArrayToHexStr(p_payload.serializeBinary()));
 
 				// 5. Build singed proposal

--- a/packages/stitch/src/libs/validation.ts
+++ b/packages/stitch/src/libs/validation.ts
@@ -467,6 +467,7 @@ interface GrpcData {
 	trailers: grpc.Metadata | null;
 	_proxy_resp: ProxyResp;
 	_b64_payload: string | null;
+	_block_data: any | undefined | null;
 }
 
 interface ProxyResp {


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix
- Improvement (improvement to code, performance, etc)

#### Description

lots of performance improvements that are mainly on the orderer modals (the side panel when viewing an orderer), but these changes will bleed over to other pages as well.

- fixed a race condition + nearly infinite loop where page spins getting the fabric version over and over, it would eventually settle after hundreds of requests
- parallelize getting root certs from CAs
- removed redundant API calls getting component details over and over
- removed the recursive behavior on the get-component-details function
- on the orderer modal, it now only calls APIs for functions that are needed for the particular modal function that was opened
- when walking the system channel to discover channel's (for the delete orderer-modal), it will now reuse the socket with the orderer and fetch the blocks in sequence, instead of opening and closing a socket for each block
