### PR TITLE
fix safe URL vaildation for legacy field "caport"

### DIFF
--- a/packages/athena/json_docs/json_validation/ibp_openapi_v2.yaml
+++ b/packages/athena/json_docs/json_validation/ibp_openapi_v2.yaml
@@ -140,7 +140,7 @@ x-validate_error_messages:
   too_many_keys: "Too many fields in body. This API only supports 1 field in the body. Use multiple apis to update multiple fields."
 
   # this value must be a known url, typically from an imported or deployed CA
-  unknown_enroll_host: "The parameter '$PROPERTY_NAME' was not found in the list of known URLs. Import the CA using this hostname & port or use a CA URL that is already known."
+  unknown_enroll_host: "The parameter '$PROPERTY_NAME' was not found in the list of known URLs. Import a CA using this host & port or change the host and port in this request to a known one"
 
   # it is invalid to upgrade fabric from version x to y
   invalid_fabric_upgrade: "Invalid '$PROPERTY_NAME' value. Upgrading Fabric from '$VALUE' to '$VALUE2' is a potentially breaking update. Read the Fabric docs for details. You can override this by setting \"ignore_warnings\" to true."

--- a/packages/athena/json_docs/json_validation/ibp_openapi_v2.yaml
+++ b/packages/athena/json_docs/json_validation/ibp_openapi_v2.yaml
@@ -139,8 +139,8 @@ x-validate_error_messages:
   # it is invalid to set more than 1 key in this body
   too_many_keys: "Too many fields in body. This API only supports 1 field in the body. Use multiple apis to update multiple fields."
 
-  # this value must be a known hostname, typically from an imported or deployed CA
-  unknown_enroll_host: "The parameter '$PROPERTY_NAME' was not found in the list of known hostnames. Import the CA using this hostname or use a hostname that is already known."
+  # this value must be a known url, typically from an imported or deployed CA
+  unknown_enroll_host: "The parameter '$PROPERTY_NAME' was not found in the list of known URLs. Import the CA using this hostname & port or use a CA URL that is already known."
 
   # it is invalid to upgrade fabric from version x to y
   invalid_fabric_upgrade: "Invalid '$PROPERTY_NAME' value. Upgrading Fabric from '$VALUE' to '$VALUE2' is a potentially breaking update. Read the Fabric docs for details. You can override this by setting \"ignore_warnings\" to true."

--- a/packages/athena/json_docs/json_validation/ibp_openapi_v3.yaml
+++ b/packages/athena/json_docs/json_validation/ibp_openapi_v3.yaml
@@ -143,7 +143,7 @@ x-validate_error_messages:
   too_many_keys: "Too many fields in body. This API only supports 1 field in the body. Use multiple apis to update multiple fields."
 
   # this value must be a known hostname, typically from an imported or deployed CA
-  unknown_enroll_host: "The parameter '$PROPERTY_NAME' was not found in the list of known urls. Import a CA using this host & port or change the host and port in this request to a known one."
+  unknown_enroll_host: "The parameter '$PROPERTY_NAME' was not found in the list of known URLs. Import a CA using this host & port or change the host and port in this request to a known one"
 
   # it is invalid to upgrade fabric from version x to y
   invalid_fabric_upgrade: "Invalid '$PROPERTY_NAME' value. Upgrading Fabric from '$VALUE' to '$VALUE2' is a potentially breaking update. Read the Fabric docs for details. You can override this by setting \"ignore_warnings\" to true."

--- a/packages/athena/libs/validation_lib.js
+++ b/packages/athena/libs/validation_lib.js
@@ -760,7 +760,9 @@ module.exports = (logger, ev, t, opts) => {
 			const regex = new RegExp(/:\d{1,5}$/, 'i');
 			if (!regex.test(input)) {														// if no port in input find "port" field in body
 				const path2parent = path2field.slice(0, path2field.length - 1).join('.');			// get path to the parent object
-				const port = t.misc.safe_dot_nav(req_body, 'req_body.' + path2parent + '.port');	// get the value of "port" in req body
+				const port = t.misc.safe_dot_nav(req_body, [								// get the value of "port" in req body
+					'req_body.' + path2parent + '.port',
+					'req_body.' + path2parent + '.caport']);
 				url_str = input + ':' + port;
 			}
 			if (!t.ot_misc.validateUrl(url_str, req._whitelist || ev.URL_SAFE_LIST)) {


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
The safe-url validation code was not working correctly if the legacy field `caport` was used. This only effects the `/v2/` APIs.

