### PR TITLE
rebuild safelist during comp edits/fabric upgrades

### DIFF
--- a/packages/athena/libs/deployer_lib.js
+++ b/packages/athena/libs/deployer_lib.js
@@ -831,11 +831,15 @@ module.exports = function (logger, ev, t) {
 								} else {
 									restart_comp_if_needed(() => {
 
-										// if we updated fabric from v2.2 to v2.4 or higher, we might now have an osn admin url (which dint' exist before)
+										// if we updated fabric from v2.2 to v2.4 or higher, we might now have an osn admin url (which didn't exist before)
 										// so we need to refresh our data to capture the new urls or w.e. -> call get_all_components, it will sync differences
 										const opts2 = { _skip_cache: true, _include_deployment_attributes: true };
 										t.deployer.get_all_components(opts2, () => {
-											return cb(null, { athena_fmt: athenaResponse, deployer_resp: fmt_ret, tx_id: parsed.debug_tx_id });
+
+											// once we sync with deployer with get_all_components(), we may need to update our whitelist to reflect new urls
+											t.component_lib.rebuildWhiteList(req, () => {
+												return cb(null, { athena_fmt: athenaResponse, deployer_resp: fmt_ret, tx_id: parsed.debug_tx_id });
+											});
 										});
 									});
 								}

--- a/packages/athena/public/releaseNotes.json
+++ b/packages/athena/public/releaseNotes.json
@@ -1,7 +1,7 @@
 [
 	{
-		"version": "1.0.5-17",
-		"date": "05 May 2023",
+		"version": "1.0.5-18",
+		"date": "08 May 2023",
 		"description": [
 			{
 				"title": "Bug & security fixes",

--- a/packages/athena/test/test-suites/routes/component_apis.test.js
+++ b/packages/athena/test/test-suites/routes/component_apis.test.js
@@ -241,6 +241,7 @@ describe('Component APIs', () => {
 				callFunction: () => {
 					tools.stubs.getDoc.callsArgWith(1, null, node_api_objects.get_single_node_response_body);
 					tools.stubs.writeDoc.callsArgWith(2, null, node_api_objects.edited_node_response_body);
+					tools.stubs.rebuildWhiteList.callsArgWith(1, null);
 				},
 				expectBlock: (res, routeInfo) => {
 					//console.log('sent', routeInfo.route, JSON.stringify(routeInfo.body));
@@ -271,6 +272,7 @@ describe('Component APIs', () => {
 					tools.stubs.getDesignDocView.callsArgWith(1, null, { rows });
 					tools.stubs.getDoc.callsArgWith(1, null, get_response);
 					tools.stubs.writeDoc.callsArgWith(2, null, node_api_objects.edited_node_response_body);
+					tools.stubs.rebuildWhiteList.callsArgWith(1, null);
 				},
 				expectBlock: (res, routeInfo) => {
 					//console.log('sent', routeInfo.route, JSON.stringify(routeInfo.body));


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
- After upgrading a fabric node we need to rebuild the internal url safe list
- after editing a component, we should rebuild the internal url  safe list

