### PR TITLE
fix anchor peer error when joining peer to channel

### DIFF
--- a/packages/apollo/src/components/JoinChannelModal/JoinChannelModal.js
+++ b/packages/apollo/src/components/JoinChannelModal/JoinChannelModal.js
@@ -373,11 +373,18 @@ class JoinChannelModal extends React.Component {
 			let allOrderers = [];
 			if (_.has(this.props.orderer, 'raft')) {
 				if (this.props.channel_orderer_addresses) {
-					allOrderers = this.props.orderer.raft.filter(x => this.props.channel_orderer_addresses.includes(_.toLower(x.backend_addr)));
+					allOrderers = this.props.orderer.raft.filter(x => {
+						return this.props.channel_orderer_addresses.includes(_.toLower(x.backend_addr));
+					});
 				} else {
 					allOrderers = this.props.orderer.raft;
 				}
 			} else {
+				allOrderers = [this.props.orderer];
+			}
+
+			// catch all if we don't find any orderers for some reason
+			if (!Array.isArray(allOrderers) || allOrderers.length === 0) {
 				allOrderers = [this.props.orderer];
 			}
 
@@ -696,6 +703,7 @@ class JoinChannelModal extends React.Component {
 			// skip step if orderer association exists
 			return;
 		}
+		// dsh todo change this.props.orderer... to this.props.selectedOrderer
 		return (
 			<WizardStep
 				type="WizardStep"

--- a/packages/apollo/src/rest/ChannelApi.js
+++ b/packages/apollo/src/rest/ChannelApi.js
@@ -1510,10 +1510,8 @@ class ChannelApi {
 					let orderers = null;
 					if (options.cluster_id) {
 						orderers = await OrdererRestApi.getClusterDetails(options.cluster_id);
-					} else {
-						orderers = await OrdererRestApi.getOrdererDetails(options.ordererId);
+						orderers = orderers.raft ? orderers.raft : null;
 					}
-					orderers = orderers.raft ? orderers.raft : [orderers];
 					const resp3 = await StitchApi.submitWithRetry(c_opts, orderers);
 					// send async event... don't wait
 					EventsRestApi.sendUpdateChannelEvent(options.channel_id, c_opts.msp_id);


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
When joining a peer to a channel (and the anchor peer toggle was enabled) it was failing to add a peer as an anchor peer to the channel.

