### PR TITLE
Improve slow loading of orderer details page

### DIFF
--- a/packages/apollo/src/components/OrdererDetails/OrdererDetails.js
+++ b/packages/apollo/src/components/OrdererDetails/OrdererDetails.js
@@ -622,7 +622,11 @@ class OrdererDetails extends Component {
 									>
 										{translate('view_release_notes')}
 									</a>
-									<Button id="patch_node" kind="primary" className="ibp-patch-button" onClick={() => this.openOrdererSettings('upgrade')}>
+									<Button id="patch_node"
+										kind="primary"
+										className="ibp-patch-button"
+										onClick={() => this.openOrdererSettings('upgrade')}
+									>
 										{translate('update_version')}
 									</Button>
 								</div>
@@ -779,12 +783,16 @@ class OrdererDetails extends Component {
 		const translate = this.props.translate;
 		return status ? (
 			<div className="ibp-node-status-container">
-				<span className={`ibp-node-status ${className}`} tabIndex="0" />
+				<span className={`ibp-node-status ${className}`}
+					tabIndex="0"
+				/>
 				<span className="ibp-node-status-label">{translate(node.operations_url ? status : 'status_undetected')}</span>
 			</div>
 		) : (
 			<div className="ibp-node-status-container">
-				<span className="ibp-node-status ibp-node-status-skeleton" tabIndex="0" />
+				<span className="ibp-node-status ibp-node-status-skeleton"
+					tabIndex="0"
+				/>
 				<span className="ibp-node-status-label">{translate('status_pending')}</span>
 			</div>
 		);
@@ -843,15 +851,24 @@ class OrdererDetails extends Component {
 								}}
 							/>
 						) : (
-							<Button id="connect-node-button" className="connect-node-button" onClick={() => this.addToSystemChannel()} disabled={this.props.disabled}>
+							<Button id="connect-node-button"
+								className="connect-node-button"
+								onClick={() => this.addToSystemChannel()}
+								disabled={this.props.disabled}
+							>
 								{translate('add_to_system_channel')}
-								<SVGs type="arrowRight" width="16px" height="16px" />
+								<SVGs type="arrowRight"
+									width="16px"
+									height="16px"
+								/>
 							</Button>
 						)}
 					</div>
 					{this.props.error && <SidePanelError error={this.props.error} />}
 				</div>
-				<RequiresAttentionImage2 className="ibp-requires-attention-image" alt="" />
+				<RequiresAttentionImage2 className="ibp-requires-attention-image"
+					alt=""
+				/>
 			</div>
 		);
 	}
@@ -869,7 +886,9 @@ class OrdererDetails extends Component {
 					<h3>{translate('running_partial')}</h3>
 					<p>{translate('running_partial_desc')}</p>
 				</div>
-				<RequiresAttentionImage className="ibp-requires-attention-image" alt="" />
+				<RequiresAttentionImage className="ibp-requires-attention-image"
+					alt=""
+				/>
 			</div>
 		);
 	}
@@ -887,7 +906,9 @@ class OrdererDetails extends Component {
 					<h3>{translate('missing_endorsement_policy_title')}</h3>
 					<p>{translate('missing_endorsement_policy_desc', { orgs: this.props.missingEndorsementOrgs.join(',') })}</p>
 				</div>
-				<RequiresAttentionImage className="ibp-requires-attention-image ibp-requires-attention-small-image" alt="" />
+				<RequiresAttentionImage className="ibp-requires-attention-image ibp-requires-attention-small-image"
+					alt=""
+				/>
 			</div>
 		);
 	}
@@ -922,11 +943,16 @@ class OrdererDetails extends Component {
 							}}
 						>
 							{translate('go_to_node')}
-							<SVGs type="arrowRight" width="16px" height="16px" />
+							<SVGs type="arrowRight"
+								width="16px"
+								height="16px"
+							/>
 						</Button>
 					</div>
 				</div>
-				<RequiresAttentionImage className="ibp-requires-attention-image" alt="" />
+				<RequiresAttentionImage className="ibp-requires-attention-image"
+					alt=""
+				/>
 			</div>
 		);
 	}
@@ -1255,7 +1281,9 @@ class OrdererDetails extends Component {
 		return (
 			<PageContainer>
 				<div>
-					<PageHeader history={this.props.history} headerName={ordererName ? translate('orderer_details_title', { ordererName: ordererName }) : ''} />
+					<PageHeader history={this.props.history}
+						headerName={ordererName ? translate('orderer_details_title', { ordererName: ordererName }) : ''}
+					/>
 					{ordererNameSkeleton}
 					<div className="ibp-orderer-details bx--row">
 						{this.props.showAddNode && (
@@ -1394,13 +1422,19 @@ class OrdererDetails extends Component {
 						<div className="bx--col-lg-12">
 							{this.props.notAvailable && (
 								<div className="ibp-not-available ibp-error-panel">
-									<SidePanelWarning title="orderer_not_available_title" subtitle="orderer_not_available_text" />
+									<SidePanelWarning title="orderer_not_available_title"
+										subtitle="orderer_not_available_text"
+									/>
 								</div>
 							)}
 							{_.get(this.props, 'usageInfo.crstatus.type') === 'Warning' && _.get(this.props, 'usageInfo.crstatus.reason') === 'certRenewalRequired' && (
 								<div className="ibp-orderer-warning ibp-error-panel">
-									<SidePanelWarning title="orderer_warning_title" subtitle="orderer_warning_text" />
-									<TranslateLink className="ibp-orderer-details-cert-expiry-link" text="cert_renew" />
+									<SidePanelWarning title="orderer_warning_title"
+										subtitle="orderer_warning_text"
+									/>
+									<TranslateLink className="ibp-orderer-details-cert-expiry-link"
+										text="cert_renew"
+									/>
 								</div>
 							)}
 							{this.props.selectedNode && !this.props.selectedNode.consenter_proposal_fin ? (
@@ -1416,10 +1450,14 @@ class OrdererDetails extends Component {
 											}}
 										>
 											{!this.props.selectedNode && (
-												<Tab id="ibp-orderer-details" label={translate('details')}>
+												<Tab id="ibp-orderer-details"
+													label={translate('details')}
+												>
 													{!this.props.loading && this.isSystemLess(this.props.details) && !this.props.orderer_tls_identity && (
 														<div>
-															<SidePanelWarning title="tls_identity_not_found" subtitle="orderer_tls_admin_identity_not_found" />
+															<SidePanelWarning title="tls_identity_not_found"
+																subtitle="orderer_tls_admin_identity_not_found"
+															/>
 														</div>
 													)}
 													{this.channelParticipationEnabled(this.props.details) && this.props.orderer_tls_identity && (
@@ -1436,7 +1474,9 @@ class OrdererDetails extends Component {
 													{!this.props.loading && !hasAssociatedIdentities && (
 														<div className="ibp-orderer-no-identity">
 															<p>{translate('orderer_no_identity')}</p>
-															<Button id="no-identity-button" onClick={() => this.openOrdererSettings('associate')}>
+															<Button id="no-identity-button"
+																onClick={() => this.openOrdererSettings('associate')}
+															>
 																{translate('associate_identity')}
 															</Button>
 														</div>
@@ -1473,7 +1513,9 @@ class OrdererDetails extends Component {
 												</Tab>
 											)}
 											{!this.props.selectedNode && (
-												<Tab id="ibp-orderer-nodes" label={translate('ordering_nodes')}>
+												<Tab id="ibp-orderer-nodes"
+													label={translate('ordering_nodes')}
+												>
 													<div className="orderer-details-nodes-container">
 														<ItemContainer
 															containerTitle="ordering_nodes"
@@ -1509,14 +1551,16 @@ class OrdererDetails extends Component {
 															this.props.selectedNode.isUpgradeAvailable &&
 															this.props.selectedNode.location === 'ibm_saas' &&
 															ActionsHelper.canCreateComponent(this.props.userInfo, this.props.feature_flags) ? (
-																<div className="ibp-details-patch-container">
-																	<div className="ibp-patch-available-tag ibp-node-details" onClick={() => this.openOrdererSettings('upgrade')}>
-																		{translate('patch_available')}
+																	<div className="ibp-details-patch-container">
+																		<div className="ibp-patch-available-tag ibp-node-details"
+																			onClick={() => this.openOrdererSettings('upgrade')}
+																		>
+																			{translate('patch_available')}
+																		</div>
 																	</div>
-																</div>
-															) : (
-																''
-															),
+																) : (
+																	''
+																),
 													})}
 												>
 													<NodeDetails node={this.props.selectedNode} />
@@ -1524,7 +1568,9 @@ class OrdererDetails extends Component {
 												</Tab>
 											)}
 											{this.isSystemLess(this.props.selectedNode) && (
-												<Tab id="ibp-orderer-channels" label={translate('channels')}>
+												<Tab id="ibp-orderer-channels"
+													label={translate('channels')}
+												>
 													<ChannelParticipationDetails
 														selectedNode={this.props.selectedNode}
 														channelList={this.props.channelList}


### PR DESCRIPTION
#### Type of change

- Improvement

#### Description
Added check for if a ordering cluster has a system channel to prevent using channel participation api unnecessarily which was slowing down the loading of the orderer details page
