### PR TITLE
remove sensitive fields from a CA response

### DIFF
--- a/packages/athena/libs/comp_formatting_lib.js
+++ b/packages/athena/libs/comp_formatting_lib.js
@@ -148,6 +148,14 @@ module.exports = function (logger, ev, t) {
 				}
 				doc = exports.redact_ak(req, doc);
 			}
+
+			// remove sensitive fields from a CA response
+			if (doc.ca && doc.ca.db) {
+				delete doc.ca.db.datasource;
+			}
+			if (doc.config_override && doc.config_override.ca && doc.config_override.ca.db) {
+				delete doc.config_override.ca.db.datasource;
+			}
 		}
 
 		return doc;										// don't sort here, sort right before responding


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement (improvement to code, performance, etc)

#### Description
 - removes the sensitive field `datasource` from component API responses (applies to CA components)

