### PR TITLE
fix orderer node options in consenter input

### DIFF
--- a/packages/apollo/src/components/ChannelModal/ChannelModal.js
+++ b/packages/apollo/src/components/ChannelModal/ChannelModal.js
@@ -1423,7 +1423,7 @@ class ChannelModal extends Component {
 		if (!_.has(selectedOrderer, 'id')) return;
 		this.props.updateState(SCOPE, { loadingConsenters: true });
 
-		OrdererRestApi.getOrdererDetails(selectedOrderer.id, true).then(orderer => {
+		OrdererRestApi.getClusterDetails(selectedOrderer.cluster_id, true).then(orderer => {
 			let getCertsFromDeployer = false;
 
 			if (orderer && orderer.raft) {
@@ -1446,6 +1446,7 @@ class ChannelModal extends Component {
 
 				// [PATH 1] - using OSN Admin features in create channel wizard
 				if (this.props.osnadmin_feats_enabled && orderer && orderer.osnadmin_url && orderer.systemless) {
+					Log.debug('using osnadmin feats');
 					this.props.updateState(SCOPE, { use_osnadmin: true }); // change the menu options
 					this.showStepsInTimeline(['osn_join_channel', 'channel_orderer_organizations']);
 					if (this.props.isChannelUpdate) {
@@ -1466,11 +1467,13 @@ class ChannelModal extends Component {
 
 				// [PATH 2] - using legacy create channel wizard
 				else {
+					Log.debug('will not use osnadmin feats...');
 					this.props.updateState(SCOPE, { use_osnadmin: false });
 					this.showStepsInTimeline(['ordering_service_organization', 'organization_creating_channel']);
 					this.hideStepsInTimeline(['osn_join_channel', 'channel_orderer_organizations']); // but hide these
 
 					if (getCertsFromDeployer) {
+						Log.debug('getting tls certs from deployer...');
 						NodeRestApi.getTLSSignedCertFromDeployer(orderer.raft)
 							.then(nodesWithCerts => {
 								Log.debug('Signed certs for raft nodes from deployer', nodesWithCerts);
@@ -1496,6 +1499,7 @@ class ChannelModal extends Component {
 								this.props.updateState(SCOPE, { raftNodes: [], isTLSUnavailable: true, loadingConsenters: false, loading: false });
 							});
 					} else {
+						Log.debug('not getting tls certs from deployer');
 						this.props.updateState(SCOPE, { raftNodes: consenters, loadingConsenters: false, loading: false });
 					}
 				}

--- a/packages/apollo/src/components/ChannelModal/Wizard/Consenters/Consenters.js
+++ b/packages/apollo/src/components/ChannelModal/Wizard/Consenters/Consenters.js
@@ -146,7 +146,7 @@ class Consenters extends Component {
 		// remove consenter options that have already been selected, match on host + port
 		if (allowed_raftNodes) {
 			if (consenters) {
-				availableConsenters = allowed_raftNodes.filter(x => !consenters.find(y => y.port === x.port && y.host === x.host));
+				availableConsenters = allowed_raftNodes.filter(x => !consenters.find(y => Number(y.port) === Number(x.port) && y.host === x.host));
 			} else {
 				availableConsenters = allowed_raftNodes;
 			}

--- a/packages/apollo/src/components/SidePanel/_sidePanel.scss
+++ b/packages/apollo/src/components/SidePanel/_sidePanel.scss
@@ -19,7 +19,7 @@
 	position: fixed;
 	right: 0;
 	top: 0;
-	width: 33.875rem;
+	width: 37rem;
 	z-index: $firstLayer;
 
 	.ibp-panel-content-flex-div {

--- a/packages/athena/json_docs/default_settings_doc.json
+++ b/packages/athena/json_docs/default_settings_doc.json
@@ -95,7 +95,7 @@
 		"remote_peer_config_enabled": true,
 		"saas_enabled": true,
 		"templates_enabled": false,
-		"scale_raft_nodes_enabled": false,
+		"scale_raft_nodes_enabled": true,
 		"hsm_enabled": false,
 		"enable_ou_identifier": true,
 		"patch_1_4to2_x_enabled": true,


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
- when editing a channel, the add/remove consenter part was not showing all the orderer nodes as options

