### PR TITLE
if comp is migrated choose correct route when getting the component status

### DIFF
--- a/packages/athena/libs/component_lib.js
+++ b/packages/athena/libs/component_lib.js
@@ -1678,12 +1678,26 @@ module.exports = function (logger, ev, t) {
 	exports.build_status_url = (comp_doc) => {
 		let ret = null;
 		if (comp_doc) {
-			if (comp_doc.type === ev.STR.CA && comp_doc.api_url) {
-				ret = comp_doc.api_url + '/cainfo';					// CA's use this route
-			} else if (comp_doc.operations_url && (comp_doc.type === ev.STR.ORDERER || comp_doc.type === ev.STR.PEER)) {
-				ret = comp_doc.operations_url + '/healthz';			// peers and orderers use this route
+
+			// if its been migrated use the legacy routes
+			if (comp_doc.migrated_from === ev.STR.LOCATION_IBP_SAAS) {
+				if (comp_doc.type === ev.STR.CA && comp_doc.api_url_saas) {
+					ret = comp_doc.api_url_saas + '/cainfo';			// CA's use this route
+				} else if (comp_doc.operations_url_saas && (comp_doc.type === ev.STR.ORDERER || comp_doc.type === ev.STR.PEER)) {
+					ret = comp_doc.operations_url_saas + '/healthz';	// peers and orderers use this route
+				}
+			}
+
+			// if it hasn't been migrated use regular routes
+			else {
+				if (comp_doc.type === ev.STR.CA && comp_doc.api_url) {
+					ret = comp_doc.api_url + '/cainfo';					// CA's use this route
+				} else if (comp_doc.operations_url && (comp_doc.type === ev.STR.ORDERER || comp_doc.type === ev.STR.PEER)) {
+					ret = comp_doc.operations_url + '/healthz';			// peers and orderers use this route
+				}
 			}
 		}
+
 		return ret;
 	};
 


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
- if a component was migrated from an iks cluster, the component status requests were using the new style of "api url" instead of the legacy style. the new style will not work on a legacy migrated component. the result is the status icon of a component in that state never goes green.

