### PR TITLE
redact registry fields even if manager

### DIFF
--- a/packages/athena/routes/deployer_apis.js
+++ b/packages/athena/routes/deployer_apis.js
@@ -393,9 +393,10 @@ module.exports = (logger, ev, t) => {
 						// ignore parsing errors
 					}
 
-					// redact CA enroll id/secret data if not a manager
-					const lc_authorized_actions = t.middleware.getActions(req);
-					if (req.path.includes('/type/ca/') && (!lc_authorized_actions || !lc_authorized_actions.includes(ev.STR.C_MANAGE_ACTION))) {
+					// redact CA enroll id/secret data
+					// i've removed the line below b/c we no longer allow managers to see the registry object - 07/11/2023
+					//const lc_authorized_actions = t.middleware.getActions(req);
+					if (req.path.includes('/type/ca/') /*&& (!lc_authorized_actions || !lc_authorized_actions.includes(ev.STR.C_MANAGE_ACTION))*/) {
 						try {
 							const obj = JSON.parse(ret);
 							// only redact the inner registry fields, else other (non-sensitive) fields will get redacted


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement (improvement to code, performance, etc)

#### Description
The `registry` field in some apis revels sensitive information to users with the manager role, this info is now removed.

