### PR TITLE
fix indexing into addresses if its not set

### DIFF
--- a/packages/apollo/src/rest/ChannelApi.js
+++ b/packages/apollo/src/rest/ChannelApi.js
@@ -709,7 +709,12 @@ class ChannelApi {
 		consenters.forEach(consenter => {
 			ordererAddresses.push(consenter.host + ':' + consenter.port);
 		});
-		node.values.OrdererAddresses.value.addresses = ordererAddresses;
+
+		// the "addresses" field is legacy for fabric, if its not already populated, don't bother updating it
+		// fabric will find orderer addresses in the "consenters" field
+		if (node.values.OrdererAddresses.value && node.values.OrdererAddresses.value.addresses) {
+			node.values.OrdererAddresses.value.addresses = ordererAddresses;
+		}
 	}
 
 	static getNodeOUIdentifier(certificate) {
@@ -1307,7 +1312,7 @@ class ChannelApi {
 		const port = parsedURL.port;
 
 		let consenterNodes = updated_json.channel_group.groups.Orderer.values.ConsensusType.value.metadata.consenters;
-		let ordererAddresses = updated_json.channel_group.values.OrdererAddresses.value.addresses;
+		let ordererAddresses = _.get(updated_json, 'channel_group.values.OrdererAddresses.value.addresses', []);
 
 		if (opts.mode === 'delete') {
 			ChannelApi.deleteConsenters(consenterNodes, ordererAddresses, host, port);

--- a/packages/apollo/src/rest/OrdererRestApi.js
+++ b/packages/apollo/src/rest/OrdererRestApi.js
@@ -323,7 +323,7 @@ class OrdererRestApi {
 
 	static async modifyConsenter(options, channel_group, orderer) {
 		let consenterNode = channel_group.groups.Orderer.values.ConsensusType.value.metadata.consenters;
-		let ordererAddresses = channel_group.values.OrdererAddresses.value.addresses;
+		let ordererAddresses = _.get(channel_group, 'values.OrdererAddresses.value.addresses', []);
 
 		let parsedURL = urlParser.parse(options.consenter_url || options.api_url);
 		const host = parsedURL.hostname;

--- a/packages/athena/public/releaseNotes.json
+++ b/packages/athena/public/releaseNotes.json
@@ -1,5 +1,15 @@
 [
 	{
+		"version": "1.0.6-1",
+		"date": "5 Sept 2023",
+		"description": [
+			{
+				"title": "Bug & security fixes",
+				"details": "Miscellaneous fixes & dependency updates."
+			}
+		]
+	},
+	{
 		"version": "1.0.5-29",
 		"date": "11 July 2023",
 		"description": [

--- a/packages/stitch/src/libs/config_block.ts
+++ b/packages/stitch/src/libs/config_block.ts
@@ -707,7 +707,8 @@ const template = {
 										"mod_policy": "/Channel/Orderer/Admins",
 										"value": {
 
-											// we are leaving this blank so that fabric uses the addresses defined in each org's section
+											// we are leaving this blank so that fabric uses the addresses defined in each org's section consenter field
+											// legacy
 											// include port, no protocol
 											"addresses": []
 										},


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
- fix front end crash when editing channel consenters when orderer does not use a system channel, `addressess` field in config block might not be set

