### PR TITLE
Showing MSP admins present in wallet while updating MSP definition

### DIFF
--- a/packages/apollo/src/assets/i18n/en/messages.json
+++ b/packages/apollo/src/assets/i18n/en/messages.json
@@ -121,6 +121,7 @@
 	"response_type_label": "Response type",
 	"response_type_tooltip": "The only supported response type is \"code\".",
 	"msp_admin_type_tooltip": "These are identities in your wallet that are also admins on this channel",
+	"msp_admin_type_label": "Known channel admins",
 	"debug_label": "User login debug logs",
 	"debug_logs_tooltip": "Extra console server logs during user login can help debug OAuth2.0 setup issues, but for maximum user privacy this setting should be off once login problems are resolved.",
 	"default_password_placeholder": "Enter a password here",

--- a/packages/apollo/src/assets/i18n/en/messages.json
+++ b/packages/apollo/src/assets/i18n/en/messages.json
@@ -120,6 +120,7 @@
 	"grant_tooltip": "The only supported grant is \"authorization_code\".",
 	"response_type_label": "Response type",
 	"response_type_tooltip": "The only supported response type is \"code\".",
+	"msp_admin_type_tooltip": "These are identities in your wallet that are also admins on this channel",
 	"debug_label": "User login debug logs",
 	"debug_logs_tooltip": "Extra console server logs during user login can help debug OAuth2.0 setup issues, but for maximum user privacy this setting should be off once login problems are resolved.",
 	"default_password_placeholder": "Enter a password here",

--- a/packages/apollo/src/components/ChannelDetails/ChannelDetails.js
+++ b/packages/apollo/src/components/ChannelDetails/ChannelDetails.js
@@ -60,6 +60,7 @@ class ChannelDetails extends Component {
 		this.msp_id = null;
 		this.acls = [];
 		this.anchorPeers = [];
+		this.orgNodes= [];
 		this.chaincode = [];
 		this.nOutOf = {
 			n: 1,
@@ -252,6 +253,8 @@ class ChannelDetails extends Component {
 							root_certs: _.get(orgNodes[orgs[i]], 'values_map.MSP.value.root_certs_list'),
 						});
 					}
+
+					this.orgNodes = orgNodes;
 
 					const ordererNodes = _.get(config, 'channel_group.groups_map.Orderer.groups_map');
 					const orderers = Object.keys(ordererNodes);
@@ -1076,6 +1079,7 @@ class ChannelDetails extends Component {
 					consenters={this.consenters}
 					loading={this.props.loading}
 					isOrdererMSP={false}
+					orgNodes={this.orgNodes}
 				/>
 				<ChannelMembers
 					id="orderer"

--- a/packages/apollo/src/components/ChannelMembers/ChannelMembers.js
+++ b/packages/apollo/src/components/ChannelMembers/ChannelMembers.js
@@ -124,6 +124,7 @@ class ChannelMembers extends Component {
 						onClose={this.hideUpdateMSPModal}
 						onComplete={this.onUpdateMspCompleted}
 						isOrdererMSP={this.props.selectedChannelMspForEdit.isOrdererMSP}
+						orgNodes={this.props.orgNodes}
 					/>
 				)}
 				{this.props.isOrdererMSP && this.props.selectedOrdererMspForEdit && (

--- a/packages/apollo/src/components/UpdateChannelMspModal/UpdateChannelMspModal.js
+++ b/packages/apollo/src/components/UpdateChannelMspModal/UpdateChannelMspModal.js
@@ -40,7 +40,7 @@ const Log = new Logger(SCOPE);
 class UpdateChannelMspModal extends React.Component {
 	componentDidMount() {
 		this.getMsps();
-		this.fetchOrgNodes();
+		this.resetState();
 	}
 
 	componentWillUnmount() {
@@ -396,23 +396,6 @@ class UpdateChannelMspModal extends React.Component {
 		}
 	}
 
-	fetchOrgNodes = () => {
-		try {
-			ChannelApi.getChannelConfig(this.props.peer.id, this.props.channelId).then(config_envelop => {
-				let config = config_envelop.config;
-				let org_nodes = _.get(config, 'channel_group.groups_map.Application.groups_map');
-				this.props.updateState(SCOPE, {
-					orgNodes: org_nodes,
-				});
-				this.resetState();
-			});
-		}
-		catch (error) {
-			Log.error(error);
-			this.resetState();
-		};
-	}
-
 	renderUploadMSPDefinition(translate) {
 		return (
 			<WizardStep
@@ -525,7 +508,6 @@ const dataProps = {
 	adminIdentites: PropTypes.array,
 	error: PropTypes.string,
 	msps: PropTypes.array,
-	orgNodes: PropTypes.array,
 	orderers: PropTypes.array,
 	selectedOrderer: PropTypes.object,
 	msp_id: PropTypes.string,

--- a/packages/apollo/src/components/UpdateChannelMspModal/UpdateChannelMspModal.js
+++ b/packages/apollo/src/components/UpdateChannelMspModal/UpdateChannelMspModal.js
@@ -197,7 +197,7 @@ class UpdateChannelMspModal extends React.Component {
 		this.props.updateState('wizard', { error });
 	}
 
-	onClose = () => {
+	onCancel = () => {
 		this.props.updateState(SCOPE, {
 			submit_identity_options: null,
 		});
@@ -478,7 +478,7 @@ class UpdateChannelMspModal extends React.Component {
 				title="update_msp_definition"
 				disable_focus_trap={true}
 				loading={this.props.loading}
-				onClose={this.onClose}
+				onClose={this.onCancel}
 				onSubmit={this.onSubmit}
 				submitButtonLabel={translate('update_msp_definition')}
 				error={this.props.error}

--- a/packages/apollo/src/components/UpdateChannelMspModal/UpdateChannelMspModal.js
+++ b/packages/apollo/src/components/UpdateChannelMspModal/UpdateChannelMspModal.js
@@ -196,6 +196,12 @@ class UpdateChannelMspModal extends React.Component {
 		this.props.updateState('wizard', { error });
 	}
 
+	onClose = () => {
+		this.props.updateState(SCOPE, {
+			submit_identity_options: null,
+		});
+	}
+
 	onSubmit = () => {
 		this.props.updateState(SCOPE, {
 			loading: true,
@@ -263,6 +269,9 @@ class UpdateChannelMspModal extends React.Component {
 						Log.info('Channel was updated successfully: ', resp);
 						this.props.onComplete(this.props.msp.id || this.props.msp.msp_id, this.props.isOrdererMSP);
 						resolve();
+						this.props.updateState(SCOPE, {
+							submit_identity_options: null,
+						});
 					})
 					.catch(error => {
 						Log.error(error);
@@ -281,6 +290,7 @@ class UpdateChannelMspModal extends React.Component {
 						this.props.updateState(SCOPE, {
 							loading: false,
 							disableSubmit: false,
+							submit_identity_options: null,
 						});
 						reject({
 							title: error_msg,
@@ -331,6 +341,31 @@ class UpdateChannelMspModal extends React.Component {
 				default: 'select_msp_id',
 			},
 		];
+		if (this.props.submit_identity_options && !this.props.isOrdererMSP && this.props.submit_identity_options.length < 6) {
+			this.props.submit_identity_options.map((admin, index) => {
+				if (!admin.cas) {
+					if (index < 1) {
+						fields.push({
+							label: 'Admins',
+							name: 'admin_identity',
+							type: 'text',
+							default: admin.name,
+							readonly: true,
+						});
+					}
+					else {
+						fields.push({
+							label: 'Admins',
+							name: 'admin_identity',
+							type: 'text',
+							default: admin.name,
+							readonly: true,
+							hideLabel: true,
+						});
+					}
+				}
+			})
+		}
 		if (!this.props.isOrdererMSP) {
 			fields.push({
 				name: 'submit_identity',

--- a/packages/apollo/src/components/UpdateChannelMspModal/UpdateChannelMspModal.js
+++ b/packages/apollo/src/components/UpdateChannelMspModal/UpdateChannelMspModal.js
@@ -200,6 +200,7 @@ class UpdateChannelMspModal extends React.Component {
 		this.props.updateState(SCOPE, {
 			submit_identity_options: null,
 		});
+		this.props.onClose();
 	}
 
 	onSubmit = () => {
@@ -471,7 +472,7 @@ class UpdateChannelMspModal extends React.Component {
 				title="update_msp_definition"
 				disable_focus_trap={true}
 				loading={this.props.loading}
-				onClose={this.props.onClose}
+				onClose={this.onClose}
 				onSubmit={this.onSubmit}
 				submitButtonLabel={translate('update_msp_definition')}
 				error={this.props.error}

--- a/packages/apollo/src/components/UpdateChannelMspModal/UpdateChannelMspModal.js
+++ b/packages/apollo/src/components/UpdateChannelMspModal/UpdateChannelMspModal.js
@@ -346,13 +346,13 @@ class UpdateChannelMspModal extends React.Component {
 		if (this.props.submit_identity_options && !this.props.isOrdererMSP) {
 			let mspAdmins = this.populateMSPAdmins();
 			fields.push({
-				label: 'Known channel admins',
+				label: 'msp_admin_type_label',
 				name: 'admin_identity',
 				type: 'component',
 				default:
 					mspAdmins.map((val, idx) =>
 						<div key={idx}>
-							<p>{val}</p>
+							<p className='admin-identity-name'>{val}</p>
 						</div>),
 				readonly: true,
 				tooltip: 'msp_admin_type_tooltip',

--- a/packages/apollo/src/components/UpdateChannelMspModal/UpdateChannelMspModal.js
+++ b/packages/apollo/src/components/UpdateChannelMspModal/UpdateChannelMspModal.js
@@ -176,6 +176,7 @@ class UpdateChannelMspModal extends React.Component {
 			disableSubmit: !this.props.isOrdererMSP,
 		});
 	}
+
 	async onSelectMSP(event) {
 		if (event.selectedMsp) {
 			this.populateMSP(event.selectedMsp);
@@ -342,30 +343,21 @@ class UpdateChannelMspModal extends React.Component {
 				default: 'select_msp_id',
 			},
 		];
-		if (this.props.submit_identity_options && !this.props.isOrdererMSP && this.props.submit_identity_options.length < 6) {
-			this.props.submit_identity_options.map((admin, index) => {
-				if (!admin.cas) {
-					if (index < 1) {
-						fields.push({
-							label: 'Admins',
-							name: 'admin_identity',
-							type: 'text',
-							default: admin.name,
-							readonly: true,
-						});
-					}
-					else {
-						fields.push({
-							label: 'Admins',
-							name: 'admin_identity',
-							type: 'text',
-							default: admin.name,
-							readonly: true,
-							hideLabel: true,
-						});
-					}
-				}
-			})
+		if (this.props.submit_identity_options && !this.props.isOrdererMSP) {
+			let mspAdmins = this.populateMSPAdmins();
+			fields.push({
+				label: 'Known channel admins',
+				name: 'admin_identity',
+				type: 'component',
+				default:
+					mspAdmins.map((val, idx) =>
+						<div key={idx}>
+							<p>{val}</p>
+						</div>),
+				readonly: true,
+				tooltip: 'msp_admin_type_tooltip',
+				tooltipDirection: 'top',
+			});
 		}
 		if (!this.props.isOrdererMSP) {
 			fields.push({
@@ -379,6 +371,20 @@ class UpdateChannelMspModal extends React.Component {
 		return fields;
 	}
 
+	populateMSPAdmins()
+	{
+		const admin_identites = [];
+		this.props.submit_identity_options.forEach(value => {
+			const parsed_msp_cert = StitchApi.parseCertificate(value.cert);
+			if (admin_identites.length < 6)
+			{
+				if (parsed_msp_cert.subject_parts.OU === 'admin') {
+					admin_identites.push(value.name);
+				}
+			}
+		});
+		return admin_identites;
+	}
 	renderUploadMSPDefinition(translate) {
 		return (
 			<WizardStep

--- a/packages/apollo/src/components/UpdateChannelMspModal/_updateChannelMspModal.scss
+++ b/packages/apollo/src/components/UpdateChannelMspModal/_updateChannelMspModal.scss
@@ -11,6 +11,11 @@
 	margin-bottom: 2rem;
 }
 
+.admin-identity-name {
+	font-size: 0.9rem;
+	margin-left: 1rem;
+}
+
 .ibp-toggle-cert-details {
 	.ibp-link {
 		background-color: transparent;


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- New feature

#### Description
This PR shows/lists the identities from the local wallet that are also admins on the channel, so that the user can make a better informed choice when selecting the identity to use when changing the MSP definition.

