### PR TITLE
Fix drilldown

### DIFF
--- a/packages/apollo/src/components/ChannelDetails/ChannelDetails.js
+++ b/packages/apollo/src/components/ChannelDetails/ChannelDetails.js
@@ -21,7 +21,7 @@ import React, { Component } from 'react';
 import { withLocalize } from 'react-localize-redux';
 import { connect } from 'react-redux';
 import emptySmartContractImage from '../../assets/images/empty_installed.svg';
-import { clearNotifications, showBreadcrumb, showError, showSuccess, updateState } from '../../redux/commonActions';
+import { clearNotifications, showBreadcrumb, showError, showSuccess, updateBreadcrumb, updateState } from '../../redux/commonActions';
 import ChannelApi from '../../rest/ChannelApi';
 import { MspRestApi } from '../../rest/MspRestApi';
 import { NodeRestApi } from '../../rest/NodeRestApi';
@@ -811,12 +811,17 @@ class ChannelDetails extends Component {
 		);
 	}
 
+	// redirect user to the route for this node
 	openNodeDetails = node => {
 		if (node.type === 'fabric-orderer' || node.type === 'orderer') {
-			this.props.history.push('/orderer/' + encodeURIComponent(node.id) + window.location.search);
+			const drillDownUrl = '/orderer/' + encodeURIComponent(node.cluster_id) + '/' + node.id;
+			this.props.showBreadcrumb('breadcrumb_name', { name: node.id }, drillDownUrl);
+			this.props.history.push(drillDownUrl);
 		}
 		if (node.type === 'fabric-peer' || node.type === 'peer') {
-			this.props.history.push('/peer/' + encodeURIComponent(node.id) + window.location.search);
+			const drillDownUrl = '/peer/' + encodeURIComponent(node.id) + window.location.search;
+			this.props.showBreadcrumb('breadcrumb_name', { name: node.id }, drillDownUrl);
+			this.props.history.push(drillDownUrl);
 		}
 	};
 
@@ -1403,6 +1408,7 @@ export default connect(
 		showError,
 		clearNotifications,
 		updateState,
+		updateBreadcrumb,
 		showSuccess,
 	}
 )(withLocalize(ChannelDetails));

--- a/packages/athena/public/releaseNotes.json
+++ b/packages/athena/public/releaseNotes.json
@@ -1,5 +1,19 @@
 [
 	{
+		"version": "1.0.6-5",
+		"date": "18 Oct 2023",
+		"description": [
+			{
+				"title": "Activity logs",
+				"details": "Added a new \"Audit\" tab that shows user and api key activity."
+			},
+			{
+				"title": "Bug & security fixes",
+				"details": "Miscellaneous fixes & dependency updates."
+			}
+		]
+	},
+	{
 		"version": "1.0.6-4",
 		"date": "02 Oct 2023",
 		"description": [


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
From the channels page, and the channel details tab, when clicking an orderer node on the channel, the app will now correctly redirect the user to the drill down of that orderer.

