### PR TITLE
Upgrade browserify-sign to 4.2.2 to address CVE.

### DIFF
--- a/packages/apollo/package-lock.json
+++ b/packages/apollo/package-lock.json
@@ -21661,7 +21661,7 @@
 			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
 			"requires": {
 				"browserify-cipher": "^1.0.0",
-				"browserify-sign": "^4.0.0",
+				"browserify-sign": "^4.2.2",
 				"create-ecdh": "^4.0.0",
 				"create-hash": "^1.1.0",
 				"create-hmac": "^1.1.0",

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -158,6 +158,7 @@
 		"semver": "^7.5.2",
 		"xml2js": "^0.5.0",
 		"optionator": "^0.9.1",
-		"tough-cookie": "^4.1.3"
+		"tough-cookie": "^4.1.3",
+		"browserify-sign": "^4.2.2"
 	}
 }


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Upgrade npm browserify-sign in apollo to 4.2.2 to address https://nvd.nist.gov/vuln/detail/CVE-2023-46234