### PR TITLE
prevent users with only a reader role from actions

### DIFF
--- a/packages/apollo/src/components/CADetails/CADetails.js
+++ b/packages/apollo/src/components/CADetails/CADetails.js
@@ -240,14 +240,14 @@ export class CADetails extends Component {
 				fn: () => {
 					this.generateCertificate(null);
 				},
-				disabled: !ActionsHelper.canEditComponent(this.props.feature_flags),
+				disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags),
 				decoupleFromLoading: true
 			});
 			buttons.push({
 				text: 'register_user',
 				fn: this.openAddUser,
 				icon: 'plus',
-				disabled: !ActionsHelper.canEditComponent(this.props.feature_flags),
+				disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags),
 				decoupleFromLoading: true
 			});
 		}
@@ -508,7 +508,7 @@ export class CADetails extends Component {
 									{
 										text: 'reallocate_resources',
 										fn: this.showUsageModal,
-										disabled: !ActionsHelper.canEditComponent(this.props.feature_flags),
+										disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags),
 									},
 								]}
 							/>

--- a/packages/apollo/src/components/Chaincodes/Chaincodes.js
+++ b/packages/apollo/src/components/Chaincodes/Chaincodes.js
@@ -144,7 +144,7 @@ class Chaincodes extends Component {
 								text: 'install_chaincode',
 								fn: this.openInstallChaincodeModal,
 								label: 'install_chaincode',
-								disabled: !ActionsHelper.canEditComponent(this.props.feature_flags)
+								disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags)
 							},
 						]}
 						disableAddItem={!this.props.peers || this.props.peers.length === 0}
@@ -194,7 +194,10 @@ Chaincodes.propTypes = {
 
 export default connect(
 	state => {
-		return Helper.mapStateToProps(state[SCOPE], dataProps);
+		let newProps = Helper.mapStateToProps(state[SCOPE], dataProps);
+		newProps['userInfo'] = state['userInfo'] ? state['userInfo'] : null;
+		newProps['feature_flags'] = state['settings'] ? state['settings']['feature_flags'] : null;
+		return newProps;
 	},
 	{
 		updateState,

--- a/packages/apollo/src/components/ChannelChaincode/ChannelChaincode.js
+++ b/packages/apollo/src/components/ChannelChaincode/ChannelChaincode.js
@@ -251,7 +251,7 @@ class ChannelChaincode extends Component {
 						{
 							text: 'chaincode_propose',
 							fn: this.openProposeChaincodeModal,
-							disabled: !ActionsHelper.canEditComponent(this.props.feature_flags)
+							disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags)
 						},
 					]}
 					select={this.openChaincodeModal}
@@ -313,6 +313,7 @@ export default connect(
 		let newProps = Helper.mapStateToProps(state[SCOPE], dataProps);
 		newProps['docPrefix'] = state['settings'] ? state['settings']['docPrefix'] : null;
 		newProps['feature_flags'] = state['settings'] ? state['settings']['feature_flags'] : null;
+		newProps['userInfo'] = state['userInfo'] ? state['userInfo'] : null;
 		return newProps;
 	},
 	{

--- a/packages/apollo/src/components/ChannelDetails/ChannelDetails.js
+++ b/packages/apollo/src/components/ChannelDetails/ChannelDetails.js
@@ -964,7 +964,7 @@ class ChannelDetails extends Component {
 							id: 'add_node',
 							text: 'add_node',
 							fn: this.showJoinChannelModal,
-							disabled: !ActionsHelper.canEditComponent(this.props.feature_flags)
+							disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags)
 						},
 					]}
 				/>
@@ -1401,6 +1401,7 @@ export default connect(
 		newProps['settings'] = state['settings'];
 		newProps['configtxlator_url'] = state['settings']['configtxlator_url'];
 		newProps['feature_flags'] = state['settings'] ? state['settings']['feature_flags'] : null;
+		newProps['userInfo'] = state['userInfo'] ? state['userInfo'] : null;
 		return newProps;
 	},
 	{

--- a/packages/apollo/src/components/Channels/Channels.js
+++ b/packages/apollo/src/components/Channels/Channels.js
@@ -637,7 +637,7 @@ class ChannelComponent extends Component {
 			id: 'join_channel',
 			text: 'join_channel',
 			fn: this.joinChannel,
-			disabled: !ActionsHelper.canEditComponent(this.props.feature_flags)
+			disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags)
 		});
 
 		const osnadminFeatsEnabled = this.props.feature_flags ? this.props.feature_flags.osnadmin_feats_enabled : false;
@@ -679,7 +679,7 @@ class ChannelComponent extends Component {
 				fn: () => {
 					this.createChannel(null);
 				},
-				disabled: !ActionsHelper.canEditComponent(this.props.feature_flags)
+				disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags)
 			});
 		}
 		return items;
@@ -975,6 +975,7 @@ export default connect(
 	state => {
 		let newProps = Helper.mapStateToProps(state[SCOPE], dataProps);
 		newProps['feature_flags'] = state['settings'] ? state['settings']['feature_flags'] : null;
+		newProps['userInfo'] = state['userInfo'] ? state['userInfo'] : null;
 		newProps['signature_requests'] = state['signatureCollection'] ? state['signatureCollection']['requests'] : [];
 		newProps['host_url'] = state['settings'] ? state['settings']['host_url'] : [];
 		return newProps;

--- a/packages/apollo/src/components/Identities/Identities.js
+++ b/packages/apollo/src/components/Identities/Identities.js
@@ -254,7 +254,7 @@ class Identities extends Component {
 									{
 										text: 'add_identity',
 										fn: this.openAddIdentity,
-										disabled: !ActionsHelper.canEditComponent(this.props.feature_flags),
+										disabled: ActionsHelper.inReadOnly(this.props.feature_flags),
 									},
 								]}
 								select={this.openIdentity}

--- a/packages/apollo/src/components/ItemContainer/ItemContainer.js
+++ b/packages/apollo/src/components/ItemContainer/ItemContainer.js
@@ -178,9 +178,8 @@ class ItemContainer extends Component {
 								<button
 									key={view}
 									id={`${this.props.id}-${view}-button`}
-									className={`ibp-container-button ${current === view ? 'ibp-active-view-mode' : 'ibp-inactive-view-mode'} ${
-										view === 'variableGrid' ? 'variableGridButton' : 'listViewButton'
-									}`}
+									className={`ibp-container-button ${current === view ? 'ibp-active-view-mode' : 'ibp-inactive-view-mode'} ${view === 'variableGrid' ? 'variableGridButton' : 'listViewButton'
+										}`}
 									onClick={view === 'variableGrid' ? this.showGrid : this.showList}
 									aria-label={view === 'variableGrid' ? 'Toggle grid view' : 'Toggle list view'}
 								>
@@ -466,7 +465,7 @@ class ItemContainer extends Component {
 							onClick={button.fn}
 							kind={button.kind || (i !== this.props.addItems.length - 1 ? 'secondary' : 'primary')}
 							title={!button.tooltip ? (button.title ? translate(button.title) : translate(button.text)) : ''}
-							disabled={button.decoupleFromLoading ? false :(this.props.disableAddItem || this.props.loading || button.disabled)}
+							disabled={button.decoupleFromLoading ? (this.props.disableAddItem || button.disabled) : (this.props.disableAddItem || this.props.loading || button.disabled)}
 						>
 							{!button.tooltip && <span className="ibp__button-text bx--type-zeta">{translate(button.text)}</span>}
 							{button.tooltip && (

--- a/packages/apollo/src/components/OrdererAdmins/OrdererAdmins.js
+++ b/packages/apollo/src/components/OrdererAdmins/OrdererAdmins.js
@@ -183,7 +183,7 @@ class OrdererAdmins extends Component {
 								fn: this.openAddMSPModal,
 								label: 'add_orderer_admin',
 								text: 'add_orderer_admin',
-								disabled: !ActionsHelper.canEditComponent(this.props.feature_flags),
+								disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags),
 							},
 						]}
 						tileMapping={{
@@ -252,7 +252,10 @@ OrdererAdmins.propTypes = {
 
 export default connect(
 	state => {
-		return Helper.mapStateToProps(state[SCOPE], dataProps);
+		let newProps = Helper.mapStateToProps(state[SCOPE], dataProps);
+		newProps['userInfo'] = state['userInfo'] ? state['userInfo'] : null;
+		newProps['feature_flags'] = state['settings'] ? state['settings']['feature_flags'] : null;
+		return newProps;
 	},
 	{
 		updateState,

--- a/packages/apollo/src/components/OrdererDetails/ChannelParticipationDetails.js
+++ b/packages/apollo/src/components/OrdererDetails/ChannelParticipationDetails.js
@@ -177,7 +177,7 @@ class ChannelParticipationDetails extends Component {
 									fn: () => {
 										this.joinChannel(null);
 									},
-									disabled: !ActionsHelper.canEditComponent(this.props.feature_flags)
+									disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags)
 								}]
 
 								: []
@@ -243,7 +243,10 @@ ChannelParticipationDetails.propTypes = {
 
 export default connect(
 	state => {
-		return Helper.mapStateToProps(state[SCOPE], dataProps);
+		let newProps = Helper.mapStateToProps(state[SCOPE], dataProps);
+		newProps['userInfo'] = state['userInfo'] ? state['userInfo'] : null;
+		newProps['feature_flags'] = state['settings'] ? state['settings']['feature_flags'] : null;
+		return newProps;
 	},
 	{
 		updateState,

--- a/packages/apollo/src/components/OrdererDetails/OrdererDetails.js
+++ b/packages/apollo/src/components/OrdererDetails/OrdererDetails.js
@@ -726,7 +726,7 @@ class OrdererDetails extends Component {
 							{
 								text: 'reallocate_resources',
 								fn: this.showUsageModal,
-								disabled: !ActionsHelper.canEditComponent(this.props.feature_flags),
+								disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags),
 							},
 						]}
 					/>

--- a/packages/apollo/src/components/OrdererMembers/OrdererMembers.js
+++ b/packages/apollo/src/components/OrdererMembers/OrdererMembers.js
@@ -147,7 +147,7 @@ class OrdererMembers extends Component {
 								fn: this.openAddMSPModal,
 								label: 'add_organization',
 								text: 'add_organization',
-								disabled: !ActionsHelper.canEditComponent(this.props.feature_flags),
+								disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags),
 							},
 						]}
 						tileMapping={{
@@ -207,7 +207,10 @@ OrdererMembers.propTypes = {
 
 export default connect(
 	state => {
-		return Helper.mapStateToProps(state[SCOPE], dataProps);
+		let newProps = Helper.mapStateToProps(state[SCOPE], dataProps);
+		newProps['userInfo'] = state['userInfo'] ? state['userInfo'] : null;
+		newProps['feature_flags'] = state['settings'] ? state['settings']['feature_flags'] : null;
+		return newProps;
 	},
 	{
 		updateState,

--- a/packages/apollo/src/components/PeerChaincode/PeerChaincode.js
+++ b/packages/apollo/src/components/PeerChaincode/PeerChaincode.js
@@ -210,7 +210,7 @@ class PeerChaincode extends Component {
 							text: 'install_chaincode',
 							fn: this.openInstallChaincodeModal,
 							label: 'install_chaincode',
-							disabled: !ActionsHelper.canEditComponent(this.props.feature_flags)
+							disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags)
 						},
 					]}
 					disableAddItem={this.props.empty || this.props.parentLoading || this.props.state !== STATES.READY}
@@ -252,7 +252,10 @@ PeerChaincode.propTypes = {
 
 export default connect(
 	state => {
-		return Helper.mapStateToProps(state[SCOPE], dataProps);
+		let newProps = Helper.mapStateToProps(state[SCOPE], dataProps);
+		newProps['userInfo'] = state['userInfo'] ? state['userInfo'] : null;
+		newProps['feature_flags'] = state['settings'] ? state['settings']['feature_flags'] : null;
+		return newProps;
 	},
 	{
 		updateState,

--- a/packages/apollo/src/components/PeerChannels/PeerChannels.js
+++ b/packages/apollo/src/components/PeerChannels/PeerChannels.js
@@ -175,7 +175,7 @@ class PeerChannels extends Component {
 							{
 								text: 'join_channel',
 								fn: this.joinChannel,
-								disabled: !ActionsHelper.canEditComponent(this.props.feature_flags)
+								disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags)
 							},
 						]}
 						disableAddItem={this.props.empty || this.props.joinInProgress}
@@ -227,7 +227,10 @@ PeerChannels.propTypes = {
 
 export default connect(
 	state => {
-		return Helper.mapStateToProps(state[SCOPE], dataProps);
+		let newProps = Helper.mapStateToProps(state[SCOPE], dataProps);
+		newProps['userInfo'] = state['userInfo'] ? state['userInfo'] : null;
+		newProps['feature_flags'] = state['settings'] ? state['settings']['feature_flags'] : null;
+		return newProps;
 	},
 	{
 		clearNotifications,

--- a/packages/apollo/src/components/PeerDetails/PeerDetails.js
+++ b/packages/apollo/src/components/PeerDetails/PeerDetails.js
@@ -396,7 +396,7 @@ class PeerDetails extends Component {
 									{
 										text: 'reallocate_resources',
 										fn: this.showUsageModal,
-										disabled: !ActionsHelper.canEditComponent(this.props.feature_flags)
+										disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags)
 									},
 								]}
 							/>

--- a/packages/apollo/src/components/StickySection/StickySection.js
+++ b/packages/apollo/src/components/StickySection/StickySection.js
@@ -170,7 +170,7 @@ const StickySection = ({
 				<p className="ibp-node-detail-title">{translate(title)}</p>
 				<div className="ibp-node-detail-icons">
 					{(details && (details.id || details.name) && !loading) ? (
-						ActionsHelper.canEditComponent(feature_flags) && <Button
+						ActionsHelper.canEditComponent(userInfo, feature_flags) && <Button
 							id={`${details.id || details.name}-sticky-settings-button`}
 							className="ibp-detail-page-icon-button"
 							kind="secondary"
@@ -193,7 +193,7 @@ const StickySection = ({
 					)}
 					{!hideRefreshCerts &&
 						((details && (details.id || details.name) && !loading) ? (
-							ActionsHelper.canEditComponent(feature_flags) && <Button
+							ActionsHelper.canEditComponent(userInfo, feature_flags) && <Button
 								id={`${details.id || details.name}-sticky-refresh-button`}
 								className="ibp-detail-page-icon-button"
 								kind="secondary"

--- a/packages/apollo/src/utils/actionsHelper.js
+++ b/packages/apollo/src/utils/actionsHelper.js
@@ -16,11 +16,19 @@
 import * as constants from './constants';
 
 const ActionsHelper = {
-	canEditComponent(feature_flags) {
+
+	// return true if the console is in read only mode
+	inReadOnly(feature_flags) {
 		const in_read_only_mode = feature_flags ? feature_flags.read_only_enabled : false;
-		return !in_read_only_mode;
+		return in_read_only_mode;
 	},
 
+	// return true if the user has the right roles to edit a component (ca/peer/orderer)
+	canEditComponent(user, feature_flags) {
+		return ActionsHelper.canCreateComponent(user, feature_flags);
+	},
+
+	// return true if the user has the right role to create a component (ca/peer/orderer)
 	canCreateComponent(user, feature_flags) {
 		const in_read_only_mode = feature_flags ? feature_flags.read_only_enabled : false;
 		return ActionsHelper._actionCheck(user, constants.ACTION_COMPONENT_CREATE) && !in_read_only_mode;


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
Prevents users with only the reader role from doing actions like:
- creating CA identities
- enrolling CA identities
- creating channels

