### PR TITLE
Add gather version button

### DIFF
--- a/packages/apollo/src/assets/i18n/en/messages.json
+++ b/packages/apollo/src/assets/i18n/en/messages.json
@@ -2846,7 +2846,9 @@
 	"log_detail_desc": "The full details of this activity log are below.",
 	"log_columns_desc": "Display",
 	"audit_no_access_msg": "Only users with the \"Manager\" role can view this page.",
-	"threat_message":"This service instance must be deleted by Oct 31, 2023 to avoid a blockchain network outage",
+	"threat_message": "This service instance must be deleted by Oct 31, 2023 to avoid a blockchain network outage",
+	"version_debug_msg": "Version summary",
+	"version_debug_tooltip": "Use this tool to export a version summary which shows the versions of each of your component. This summary is helpful for debugging/support purposes.",
 	"hide_archived_channels": "Hide Archived Channels",
 	"show_archived_channels": "Show Archived Channels"
 }

--- a/packages/apollo/src/components/Settings/_settings.scss
+++ b/packages/apollo/src/components/Settings/_settings.scss
@@ -92,9 +92,9 @@
 	margin-bottom: 2rem;
 }
 
-.ibp-settings-bulk-data-container {
+/*.ibp-settings-bulk-data-container {
 	padding-top: 1rem;
-}
+}*/
 
 #ibp-progress-bar-wrap {
 	width: 19rem;

--- a/packages/apollo/src/rest/NodeRestApi.js
+++ b/packages/apollo/src/rest/NodeRestApi.js
@@ -1168,6 +1168,11 @@ class NodeRestApi {
 	static async deleteAllComponents() {
 		return await RestApi.delete('/saas/api/v3/components/purge');
 	}
+
+	// get version summary on all components
+	static async getVersionSummary() {
+		return await RestApi.get('/api/v3/versions');
+	}
 }
 
 export { NodeRestApi, CREATED_COMPONENT_LOCATION, isCreatedComponentLocation };

--- a/packages/apollo/src/utils/helper.js
+++ b/packages/apollo/src/utils/helper.js
@@ -301,6 +301,7 @@ const Helper = {
 			createTarget.removeChild(link);
 		}
 	},
+
 	/*
 	 * Export a nodes as Zip
 	 */

--- a/packages/athena/libs/misc.js
+++ b/packages/athena/libs/misc.js
@@ -1524,5 +1524,25 @@ module.exports = function (logger, t) {
 		}
 	};
 
+	// turn version into a 3 part version string
+	// 'V2_0' -> 'v2.0.0'
+	// '2.0.0' -> 'v2.0.0'
+	// 'V1_4_2' -> 'v1.4.2'
+	exports.prettyPrintVersion = (str) => {
+		if (typeof str === 'string') {
+			if (str === 'unknown') { return '-'; }
+			str = str.trim();
+			if (str[0].toUpperCase() === 'V') {
+				str = str.substring(1);			// cut off the 'V'
+			}
+			const parts = str.includes('_') ? str.split('_') : str.split('.');
+			while (parts.length < 3) {
+				parts.push('0');
+			}
+			return 'v' + parts.join('.');
+		}
+		return '-';
+	};
+
 	return exports;
 };

--- a/packages/athena/libs/other_apis_lib.js
+++ b/packages/athena/libs/other_apis_lib.js
@@ -912,10 +912,10 @@ module.exports = function (logger, ev, t) {
 			components: [],
 			cluster: {
 				type: '',
-				version: ''
+				version: '',
+				go_version: '',
 			},
 			operator: {
-				version: '',
 				available_fabric_versions: {}
 			},
 			timestamp: Date.now(),
@@ -992,6 +992,7 @@ module.exports = function (logger, ev, t) {
 						return join(null);
 					} else {
 						ret.cluster.version = (resp && resp._version) ? t.misc.prettyPrintVersion(resp._version) : '-';
+						ret.cluster.go_version = (resp && resp.goVersion) ? resp.goVersion : '-';
 						return join(null, resp);
 					}
 				});
@@ -1017,7 +1018,17 @@ module.exports = function (logger, ev, t) {
 						// error already logged
 						join(null);
 					} else {
-						ret.operator.versions = (resp && resp.versions) ? resp.versions : {};
+						const tmp = (resp && resp.versions) ? resp.versions : {};
+						const types = ['peer', 'orderer', 'ca'];
+						for (let i in types) {
+							const fab_type = types[i];
+							if (tmp && tmp[fab_type]) {
+								ret.operator.available_fabric_versions[fab_type] = [];
+								for (let ver in tmp.peer) {
+									ret.operator.available_fabric_versions[fab_type].push(t.misc.prettyPrintVersion(ver));
+								}
+							}
+						}
 						join(null, resp.versions);
 					}
 				});

--- a/packages/athena/routes/other_apis.js
+++ b/packages/athena/routes/other_apis.js
@@ -528,5 +528,19 @@ module.exports = function (logger, ev, t) {
 		});
 	});
 
+	//-----------------------------------------------------------------------------
+	// Return the debug/support version summary
+	// dsh todo - doc this api
+	//-----------------------------------------------------------------------------
+	app.get('/api/v[3]/versions', t.middleware.verify_view_action_session, (req, res) => {
+		t.other_apis_lib.version_summary(req, (err, ret) => {
+			if (err) {
+				return res.status(t.ot_misc.get_code(err)).json(err);
+			} else {
+				return res.status(200).json(ret);
+			}
+		});
+	});
+
 	return app;
 };

--- a/packages/athena/routes/other_apis.js
+++ b/packages/athena/routes/other_apis.js
@@ -530,7 +530,6 @@ module.exports = function (logger, ev, t) {
 
 	//-----------------------------------------------------------------------------
 	// Return the debug/support version summary
-	// dsh todo - doc this api
 	//-----------------------------------------------------------------------------
 	app.get('/api/v[3]/versions', t.middleware.verify_view_action_session, (req, res) => {
 		t.other_apis_lib.version_summary(req, (err, ret) => {


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- New feature

#### Description
Adds a new button under the `settings` tab. it will generate a json file of all component versions, operator fabric versions, and the console version. this is useful for support.

![image](https://github.com/hyperledger-labs/fabric-operations-console/assets/16085295/908daaa8-5503-41df-ab8c-21fa27291dbe)

