### PR TITLE
fix user roles/permissions on fabric operations

### DIFF
--- a/packages/apollo/src/components/CADetails/CADetails.js
+++ b/packages/apollo/src/components/CADetails/CADetails.js
@@ -240,14 +240,14 @@ export class CADetails extends Component {
 				fn: () => {
 					this.generateCertificate(null);
 				},
-				disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags),
+				disabled: !ActionsHelper.canManageComponent(this.props.userInfo, this.props.feature_flags),
 				decoupleFromLoading: true
 			});
 			buttons.push({
 				text: 'register_user',
 				fn: this.openAddUser,
 				icon: 'plus',
-				disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags),
+				disabled: !ActionsHelper.canManageComponent(this.props.userInfo, this.props.feature_flags),
 				decoupleFromLoading: true
 			});
 		}
@@ -294,6 +294,7 @@ export class CADetails extends Component {
 									this.showDeleteUserModal(user);
 								},
 								requireTitle: true,
+								disabled: !ActionsHelper.canManageComponent(this.props.userInfo, this.props.feature_flags),
 							},
 						]}
 						listMapping={[
@@ -508,7 +509,7 @@ export class CADetails extends Component {
 									{
 										text: 'reallocate_resources',
 										fn: this.showUsageModal,
-										disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags),
+										disabled: !ActionsHelper.canCreateComponent(this.props.userInfo, this.props.feature_flags),
 									},
 								]}
 							/>

--- a/packages/apollo/src/components/Chaincodes/Chaincodes.js
+++ b/packages/apollo/src/components/Chaincodes/Chaincodes.js
@@ -102,7 +102,6 @@ class Chaincodes extends Component {
 		);
 		return overflow;
 	};
-
 	render() {
 		return (
 			<div>
@@ -144,7 +143,7 @@ class Chaincodes extends Component {
 								text: 'install_chaincode',
 								fn: this.openInstallChaincodeModal,
 								label: 'install_chaincode',
-								disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags)
+								disabled: !ActionsHelper.canManageComponent(this.props.userInfo, this.props.feature_flags)
 							},
 						]}
 						disableAddItem={!this.props.peers || this.props.peers.length === 0}

--- a/packages/apollo/src/components/ChannelAnchorPeers/ChannelAnchorPeers.js
+++ b/packages/apollo/src/components/ChannelAnchorPeers/ChannelAnchorPeers.js
@@ -18,6 +18,7 @@ import React from 'react';
 import emptyAnchorPeerImage from '../../assets/images/empty_nodes.svg';
 import ItemContainer from '../ItemContainer/ItemContainer';
 import SVGs from '../Svgs/Svgs';
+import ActionsHelper from '../../utils/actionsHelper';
 
 const ChannelAnchorPeers = props => {
 	return (
@@ -64,6 +65,7 @@ const ChannelAnchorPeers = props => {
 					{
 						text: 'add_anchor_peer',
 						fn: props.openAddAnchorPeerModal,
+						disabled: !ActionsHelper.canManageComponent(props.userInfo, props.feature_flags),
 					},
 				]}
 			/>
@@ -77,6 +79,8 @@ ChannelAnchorPeers.propTypes = {
 	loading: PropTypes.bool,
 	disableDelete: PropTypes.bool,
 	onDeleteAnchorPeers: PropTypes.func,
+	userInfo: PropTypes.object,
+	feature_flags: PropTypes.object,
 	translate: PropTypes.func, // Provided by withLocalize
 };
 

--- a/packages/apollo/src/components/ChannelChaincode/ChannelChaincode.js
+++ b/packages/apollo/src/components/ChannelChaincode/ChannelChaincode.js
@@ -251,7 +251,7 @@ class ChannelChaincode extends Component {
 						{
 							text: 'chaincode_propose',
 							fn: this.openProposeChaincodeModal,
-							disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags)
+							disabled: !ActionsHelper.canManageComponent(this.props.userInfo, this.props.feature_flags)
 						},
 					]}
 					select={this.openChaincodeModal}

--- a/packages/apollo/src/components/ChannelDetails/ChannelDetails.js
+++ b/packages/apollo/src/components/ChannelDetails/ChannelDetails.js
@@ -964,7 +964,7 @@ class ChannelDetails extends Component {
 							id: 'add_node',
 							text: 'add_node',
 							fn: this.showJoinChannelModal,
-							disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags)
+							disabled: !ActionsHelper.canManageComponent(this.props.userInfo, this.props.feature_flags)
 						},
 					]}
 				/>
@@ -1000,6 +1000,7 @@ class ChannelDetails extends Component {
 								fn: () => {
 									this.openDeleteConsenterModal(node);
 								},
+								disabled: !ActionsHelper.canManageComponent(this.props.userInfo, this.props.feature_flags),
 							},
 						];
 						if (node.tls_cert_mismatch) {
@@ -1008,6 +1009,7 @@ class ChannelDetails extends Component {
 								fn: () => {
 									this.openUpdateConsenterModal(node);
 								},
+								disabled: !ActionsHelper.canManageComponent(this.props.userInfo, this.props.feature_flags),
 							});
 						}
 						return items;
@@ -1108,6 +1110,8 @@ class ChannelDetails extends Component {
 					disableDelete={!this.channel.orderers || !this.channel.orderers.length}
 					onDeleteAnchorPeers={this.deleteAnchorPeers}
 					translate={this.props.translate}
+					feature_flags={this.props.feature_flags}
+					userInfo={this.props.userInfo}
 				/>
 			</div>
 		);
@@ -1163,6 +1167,7 @@ class ChannelDetails extends Component {
 				label: 'add_anchor_peer',
 				quickAction: this.openAddAnchorPeerModal,
 				loadingData: !this.props.blocks.length && this.props.anchorPeersLoading,
+				disabled: !ActionsHelper.canManageComponent(this.props.userInfo, this.props.feature_flags),
 			},
 		];
 

--- a/packages/apollo/src/components/Channels/Channels.js
+++ b/packages/apollo/src/components/Channels/Channels.js
@@ -637,7 +637,7 @@ class ChannelComponent extends Component {
 			id: 'join_channel',
 			text: 'join_channel',
 			fn: this.joinChannel,
-			disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags)
+			disabled: !ActionsHelper.canManageComponent(this.props.userInfo, this.props.feature_flags)
 		});
 
 		const osnadminFeatsEnabled = this.props.feature_flags ? this.props.feature_flags.osnadmin_feats_enabled : false;
@@ -679,7 +679,7 @@ class ChannelComponent extends Component {
 				fn: () => {
 					this.createChannel(null);
 				},
-				disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags)
+				disabled: !ActionsHelper.canManageComponent(this.props.userInfo, this.props.feature_flags)
 			});
 		}
 		return items;

--- a/packages/apollo/src/components/ItemMenu/ItemMenu.js
+++ b/packages/apollo/src/components/ItemMenu/ItemMenu.js
@@ -53,6 +53,7 @@ class ItemMenu extends Component {
 								}}
 								primaryFocus={index === 0}
 								requireTitle={option.requireTitle ? true : false}
+								disabled={option.disabled === true}
 							/>
 						);
 					})}

--- a/packages/apollo/src/components/ItemMenu/_itemMenu.scss
+++ b/packages/apollo/src/components/ItemMenu/_itemMenu.scss
@@ -42,6 +42,12 @@
 	background-color: $carbon--cool-gray-80;
 
 	&:hover {
-		background-color: $carbon--cool-gray-90  !important;
+		background-color: $carbon--cool-gray-90 !important;
+	}
+}
+
+.bx--overflow-menu-options__option--disabled {
+	button {
+		color: #697075;
 	}
 }

--- a/packages/apollo/src/components/OrdererAdmins/OrdererAdmins.js
+++ b/packages/apollo/src/components/OrdererAdmins/OrdererAdmins.js
@@ -183,7 +183,7 @@ class OrdererAdmins extends Component {
 								fn: this.openAddMSPModal,
 								label: 'add_orderer_admin',
 								text: 'add_orderer_admin',
-								disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags),
+								disabled: !ActionsHelper.canManageComponent(this.props.userInfo, this.props.feature_flags),
 							},
 						]}
 						tileMapping={{

--- a/packages/apollo/src/components/OrdererDetails/ChannelParticipationDetails.js
+++ b/packages/apollo/src/components/OrdererDetails/ChannelParticipationDetails.js
@@ -177,7 +177,7 @@ class ChannelParticipationDetails extends Component {
 									fn: () => {
 										this.joinChannel(null);
 									},
-									disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags)
+									disabled: !ActionsHelper.canManageComponent(this.props.userInfo, this.props.feature_flags)
 								}]
 
 								: []

--- a/packages/apollo/src/components/OrdererDetails/OrdererDetails.js
+++ b/packages/apollo/src/components/OrdererDetails/OrdererDetails.js
@@ -726,7 +726,7 @@ class OrdererDetails extends Component {
 							{
 								text: 'reallocate_resources',
 								fn: this.showUsageModal,
-								disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags),
+								disabled: !ActionsHelper.canCreateComponent(this.props.userInfo, this.props.feature_flags),
 							},
 						]}
 					/>
@@ -1227,6 +1227,7 @@ class OrdererDetails extends Component {
 									fn: () => {
 										this.openDeleteConsenterModal(member);
 									},
+									disabled: !ActionsHelper.canManageComponent(this.props.userInfo, this.props.feature_flags),
 								},
 							];
 						}
@@ -1239,6 +1240,7 @@ class OrdererDetails extends Component {
 								fn: () => {
 									this.openUpdateConsenterModal(member);
 								},
+								disabled: !ActionsHelper.canManageComponent(this.props.userInfo, this.props.feature_flags),
 							});
 						}
 						return items;

--- a/packages/apollo/src/components/OrdererMembers/OrdererMembers.js
+++ b/packages/apollo/src/components/OrdererMembers/OrdererMembers.js
@@ -147,7 +147,7 @@ class OrdererMembers extends Component {
 								fn: this.openAddMSPModal,
 								label: 'add_organization',
 								text: 'add_organization',
-								disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags),
+								disabled: !ActionsHelper.canCreateComponent(this.props.userInfo, this.props.feature_flags),
 							},
 						]}
 						tileMapping={{

--- a/packages/apollo/src/components/PeerChaincode/PeerChaincode.js
+++ b/packages/apollo/src/components/PeerChaincode/PeerChaincode.js
@@ -210,7 +210,7 @@ class PeerChaincode extends Component {
 							text: 'install_chaincode',
 							fn: this.openInstallChaincodeModal,
 							label: 'install_chaincode',
-							disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags)
+							disabled: !ActionsHelper.canManageComponent(this.props.userInfo, this.props.feature_flags)
 						},
 					]}
 					disableAddItem={this.props.empty || this.props.parentLoading || this.props.state !== STATES.READY}

--- a/packages/apollo/src/components/PeerChannels/PeerChannels.js
+++ b/packages/apollo/src/components/PeerChannels/PeerChannels.js
@@ -175,7 +175,7 @@ class PeerChannels extends Component {
 							{
 								text: 'join_channel',
 								fn: this.joinChannel,
-								disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags)
+								disabled: !ActionsHelper.canManageComponent(this.props.userInfo, this.props.feature_flags)
 							},
 						]}
 						disableAddItem={this.props.empty || this.props.joinInProgress}

--- a/packages/apollo/src/components/PeerDetails/PeerDetails.js
+++ b/packages/apollo/src/components/PeerDetails/PeerDetails.js
@@ -396,7 +396,7 @@ class PeerDetails extends Component {
 									{
 										text: 'reallocate_resources',
 										fn: this.showUsageModal,
-										disabled: !ActionsHelper.canEditComponent(this.props.userInfo, this.props.feature_flags)
+										disabled: !ActionsHelper.canCreateComponent(this.props.userInfo, this.props.feature_flags)
 									},
 								]}
 							/>

--- a/packages/apollo/src/components/StickySection/StickySection.js
+++ b/packages/apollo/src/components/StickySection/StickySection.js
@@ -170,7 +170,7 @@ const StickySection = ({
 				<p className="ibp-node-detail-title">{translate(title)}</p>
 				<div className="ibp-node-detail-icons">
 					{(details && (details.id || details.name) && !loading) ? (
-						ActionsHelper.canEditComponent(userInfo, feature_flags) && <Button
+						ActionsHelper.canCreateComponent(userInfo, feature_flags) && <Button
 							id={`${details.id || details.name}-sticky-settings-button`}
 							className="ibp-detail-page-icon-button"
 							kind="secondary"
@@ -193,7 +193,7 @@ const StickySection = ({
 					)}
 					{!hideRefreshCerts &&
 						((details && (details.id || details.name) && !loading) ? (
-							ActionsHelper.canEditComponent(userInfo, feature_flags) && <Button
+							ActionsHelper.canCreateComponent(userInfo, feature_flags) && <Button
 								id={`${details.id || details.name}-sticky-refresh-button`}
 								className="ibp-detail-page-icon-button"
 								kind="secondary"

--- a/packages/apollo/src/index.scss
+++ b/packages/apollo/src/index.scss
@@ -155,11 +155,11 @@ small {
 .bx--overflow-menu-options::before {
 	display: none;
 }
-
+/* interferes with overflow menu when button is disabled, seems like we dont' need it, removed
 .bx--overflow-menu-options .bx--overflow-menu-options__btn {
 	color: $text;
 }
-
+*/
 .bx--overflow-sdk-item-btn {
 	height: 2.95rem;
 }

--- a/packages/apollo/src/utils/actionsHelper.js
+++ b/packages/apollo/src/utils/actionsHelper.js
@@ -23,11 +23,6 @@ const ActionsHelper = {
 		return in_read_only_mode;
 	},
 
-	// return true if the user has the right roles to edit a component (ca/peer/orderer)
-	canEditComponent(user, feature_flags) {
-		return ActionsHelper.canCreateComponent(user, feature_flags);
-	},
-
 	// return true if the user has the right role to create a component (ca/peer/orderer)
 	canCreateComponent(user, feature_flags) {
 		const in_read_only_mode = feature_flags ? feature_flags.read_only_enabled : false;
@@ -39,6 +34,12 @@ const ActionsHelper = {
 		const in_read_only_mode = feature_flags ? feature_flags.read_only_enabled : false;
 		return ActionsHelper._actionCheck(user, constants.ACTION_COMPONENT_REMOVE) && !in_read_only_mode;
 	},*/
+
+	// return true if the user has the right role to manage fabric nouns (ca identities/config blocks/channels)
+	canManageComponent(user, feature_flags) {
+		const in_read_only_mode = feature_flags ? feature_flags.read_only_enabled : false;
+		return ActionsHelper._actionCheck(user, constants.ACTION_COMPONENT_MANAGE) && !in_read_only_mode;
+	},
 
 	canDeleteComponent(user, feature_flags) {
 		const in_read_only_mode = feature_flags ? feature_flags.read_only_enabled : false;

--- a/packages/apollo/src/utils/constants.js
+++ b/packages/apollo/src/utils/constants.js
@@ -29,6 +29,7 @@ export const ACTION_COMPONENT_REMOVE = 'blockchain.components.remove';
 export const ACTION_COMPONENT_DELETE = 'blockchain.components.delete';
 export const ACTION_COMPONENT_IMPORT = 'blockchain.components.import';
 export const ACTION_COMPONENT_EXPORT = 'blockchain.components.export';
+export const ACTION_COMPONENT_MANAGE = 'blockchain.components.manage';
 export const ACTION_OPTOOLS_RESTART = 'blockchain.optools.restart';
 export const ACTION_OPTOOLS_LOGS = 'blockchain.optools.logs';
 export const ACTION_OPTOOLS_VIEW = 'blockchain.optools.view';

--- a/packages/apollo/test/unit/tests/CADetails.test.jsx
+++ b/packages/apollo/test/unit/tests/CADetails.test.jsx
@@ -32,7 +32,7 @@ const should = chai.should();
 jest.mock('../../../src/utils/actionsHelper', () => {
 	return {
 		canCreateComponent: () => true,
-		canEditComponent: () => true,
+		canManageComponent: () => true,
 	};
 });
 

--- a/packages/apollo/test/unit/tests/CAModal.test.jsx
+++ b/packages/apollo/test/unit/tests/CAModal.test.jsx
@@ -30,7 +30,7 @@ const should = chai.should();
 jest.mock('../../../src/utils/actionsHelper', () => {
 	return {
 		canCreateComponent: () => true,
-		canEditComponent: () => true,
+		canManageComponent: () => true,
 	};
 });
 

--- a/packages/apollo/test/unit/tests/CertificateAuthority.test.jsx
+++ b/packages/apollo/test/unit/tests/CertificateAuthority.test.jsx
@@ -32,7 +32,7 @@ jest.mock('../../../src/utils/actionsHelper', () => {
 	return {
 		canCreateComponent: () => true,
 		canImportComponent: () => true,
-		canEditComponent: () => true,
+		canManageComponent: () => true,
 	};
 });
 

--- a/packages/apollo/test/unit/tests/Settings.test.jsx
+++ b/packages/apollo/test/unit/tests/Settings.test.jsx
@@ -82,7 +82,7 @@ jest.mock('../../../src/components/ImportModal/ImportModal', () => {
 jest.mock('../../../src/utils/actionsHelper', () => {
 	return {
 		canImportComponent: userInfo => !!(userInfo && userInfo.canImportComponent),
-		canEditComponent: () => true,
+		canManageComponent: () => true,
 	};
 });
 

--- a/packages/athena/docs/_permissions.md
+++ b/packages/athena/docs/_permissions.md
@@ -72,6 +72,7 @@ Users (and api keys) will be assigned roles, and roles will contain these action
 Users without the needed action, will not be allowed to perform that function.
   - `blockchain.components.create`
     - can **deploy** components (creates a peer/orderer/ca kubernetes deployment)
+    - can change component resources
   - `blockchain.components.delete`
     - can remove **deployed** components
   - `blockchain.components.remove`
@@ -111,6 +112,8 @@ Users without the needed action, will not be allowed to perform that function.
     - can run the component /actions api (such as restart, re-enroll, enroll
     - can create/delete config-block docs
     - can migrate a console to another cluster
+    - can install chaincode
+    - can create channels
   - `blockchain.instance.link` - a hyperion action (deprecated)
     - can create a resource, associating it with a cluster
   - `blockchain.instance.view` - a hyperion action (deprecated)


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
- users that are readers can no longer:
    -  delete CA identities
    - install smart contracts
    - remove ordering service consenters from an app channel
    - add anchor peers to an app channel

