### PR TITLE
reverting 573 b/c of broken export/import flow

### DIFF
--- a/packages/apollo/src/utils/helper.js
+++ b/packages/apollo/src/utils/helper.js
@@ -217,7 +217,7 @@ const Helper = {
 				cluster_name: node.cluster_name,
 				client_tls_cert: node.client_tls_cert,
 				server_tls_cert: node.server_tls_cert,
-				location: node.location,
+				location: node.location === 'ibm_saas' ? this.getPlatform() : node.location,
 				id: node.id,
 				scheme_version: node.scheme_version,
 				migrated_from: node.migrated_from ? node.migrated_from : undefined,

--- a/packages/athena/public/releaseNotes.json
+++ b/packages/athena/public/releaseNotes.json
@@ -1,7 +1,7 @@
 [
 	{
-		"version": "1.0.8-3",
-		"date": "04 Jan 2023",
+		"version": "1.0.8-4",
+		"date": "05 Jan 2024",
 		"description": [
 			{
 				"title": "Bug & security fixes",


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
The change in https://github.com/hyperledger-labs/fabric-operations-console/pull/573/files sets the location field differently which breaks exporting/importing components. Undoing.

