### PR TITLE
prevent the axios wrapper from deleting body arg

### DIFF
--- a/packages/athena/libs/request_axios.js
+++ b/packages/athena/libs/request_axios.js
@@ -30,13 +30,11 @@ module.exports = function (axios) {
 		// convert `body` -> `data`
 		if (options && options.body) {
 			options.data = options.body;
-			delete options.body;
 		}
 
 		// convert `uri` -> `url`
 		if (options && options.uri) {
 			options.url = options.uri;
-			delete options.uri;
 		}
 
 		// merge `baseUrl` with `url`, axios doesn't play nice otherwise
@@ -115,6 +113,11 @@ module.exports = function (axios) {
 			if (resp.status) {
 				resp.statusCode = resp.status;
 				delete resp.status;
+			}
+
+			// undo the `body` -> `data` INPUT arg conversion
+			if (options && options.data) {
+				options.data = undefined;
 			}
 
 			/*if (resp.body && resp.headers['content-type'] && resp.headers['content-type'].includes('grpc-web') ||

--- a/packages/athena/package-lock.json
+++ b/packages/athena/package-lock.json
@@ -22,7 +22,7 @@
 				"express-session": "1.15.*",
 				"http-proxy": "1.18.*",
 				"js-yaml": "^4.1.0",
-				"jsrsasign": "^10.5.25",
+				"jsrsasign": "^11.0.0",
 				"node-cache": "5.1.*",
 				"owasp-password-strength-test": "^1.3.0",
 				"passport": "^0.6.0",
@@ -3104,9 +3104,9 @@
 			}
 		},
 		"node_modules/jsrsasign": {
-			"version": "10.5.25",
-			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.25.tgz",
-			"integrity": "sha512-N7zxHaCwYvFlXsybq4p4RxRwn4AbEq3cEiyjbCrWmwA7g8aS4LTKDJ9AJmsXxwtYesYx0imJ+ITtkyyxLCgeIg==",
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-11.0.0.tgz",
+			"integrity": "sha512-BtRwVKS+5dsgPpAtzJcpo5OoWjSs1/zllSBG0+8o8/aV0Ki76m6iZwHnwnsqoTdhfFZDN1XIdcaZr5ZkP+H2gg==",
 			"funding": {
 				"url": "https://github.com/kjur/jsrsasign#donations"
 			}
@@ -7754,9 +7754,9 @@
 			"dev": true
 		},
 		"jsrsasign": {
-			"version": "10.5.25",
-			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.5.25.tgz",
-			"integrity": "sha512-N7zxHaCwYvFlXsybq4p4RxRwn4AbEq3cEiyjbCrWmwA7g8aS4LTKDJ9AJmsXxwtYesYx0imJ+ITtkyyxLCgeIg=="
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-11.0.0.tgz",
+			"integrity": "sha512-BtRwVKS+5dsgPpAtzJcpo5OoWjSs1/zllSBG0+8o8/aV0Ki76m6iZwHnwnsqoTdhfFZDN1XIdcaZr5ZkP+H2gg=="
 		},
 		"just-extend": {
 			"version": "4.0.2",

--- a/packages/athena/package.json
+++ b/packages/athena/package.json
@@ -40,7 +40,7 @@
 		"express-session": "1.15.*",
 		"http-proxy": "1.18.*",
 		"js-yaml": "^4.1.0",
-		"jsrsasign": "^10.5.25",
+		"jsrsasign": "^11.0.0",
 		"node-cache": "5.1.*",
 		"owasp-password-strength-test": "^1.3.0",
 		"passport": "^0.6.0",

--- a/packages/athena/test/axios.js
+++ b/packages/athena/test/axios.js
@@ -48,15 +48,16 @@ tools.root_misc = require('../libs/root_misc.js')(logger);
 tools.misc = require('../libs/misc.js')(logger, tools);
 tools.ot_misc = require('../libs/ot_misc.js')(logger, tools);
 
-
 const opts = {
 	method: 'GET',
 	uri: 'http://localhost:3000/api/v3/settings',
+	body: { 'this': 'should remain' },
 };
 tools.misc.retry_req(opts, (err, resp) => {
 	console.log('returned to code');
 	let response = resp ? resp.body : null;
 	let code = tools.ot_misc.get_code(resp);
+	console.log('body after:', opts.body);
 
 	if (err) {
 		console.log('comm error', err);

--- a/packages/stitch/package-lock.json
+++ b/packages/stitch/package-lock.json
@@ -2313,9 +2313,9 @@
 			}
 		},
 		"node_modules/get-func-name": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+			"integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
 			"dev": true,
 			"engines": {
 				"node": "*"
@@ -7316,9 +7316,9 @@
 			"dev": true
 		},
 		"get-func-name": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+			"integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
 			"dev": true
 		},
 		"get-stream": {


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
- The axios wrapper introduced in `1.0.8-4` was copying the `body` filed to `data`, and then deleting `body` which led to errors when the code later tried to use `body`. This error surfaced in the UI with newly created components having blank names/tiles. Other internal fields were also missing.
- also fixes some npm dependency cves

