### PR TITLE
fix mutual tls reqs with axios http lib

### DIFF
--- a/packages/apollo/src/components/JoinOSNChannelModal/JoinOSNChannelModal.js
+++ b/packages/apollo/src/components/JoinOSNChannelModal/JoinOSNChannelModal.js
@@ -500,9 +500,12 @@ class JoinOSNChannelModal extends React.Component {
 			clone._selected = selected;
 
 			if (node_obj && channel_data && channel_data.nodes && channel_data.nodes[node_obj._id]) {
-				if (channel_data.nodes[node_obj._id]._channel_resp && channel_data.nodes[node_obj._id]._channel_resp.name) {
-					clone._status = constants.OSN_JOIN_SUCCESS;
-					clone._selected = false;			// don't select a;ready joined nodes
+				if (channel_data.nodes[node_obj._id]._channel_resp) {
+					if (channel_data.nodes[node_obj._id]._channel_resp.status === constants.FAB_JOINED_STATUS ||
+						channel_data.nodes[node_obj._id]._channel_resp.status === constants.FAB_JOINING_STATUS) {
+						clone._status = constants.OSN_JOIN_SUCCESS;
+						clone._selected = false;			// don't select a;ready joined nodes
+					}
 				}
 			}
 

--- a/packages/apollo/src/utils/constants.js
+++ b/packages/apollo/src/utils/constants.js
@@ -67,6 +67,8 @@ export const SECONDARY_STATUS_PERIOD = 1 * 60 * 1000;
 export const OSN_JOIN_SUCCESS = 'success';
 export const OSN_JOIN_PENDING = 'pending';
 export const OSN_JOIN_ERROR = 'failed';
+export const FAB_JOINED_STATUS = 'active';
+export const FAB_JOINING_STATUS = 'onboarding';
 
 // migration status summary
 export const STATUS_IN_PROGRESS = 'in-progress';

--- a/packages/athena/libs/request_axios.js
+++ b/packages/athena/libs/request_axios.js
@@ -21,11 +21,13 @@
 module.exports = function (axios) {
 	const ARRAY_BUFFER_TYPE = 'arraybuffer';	// axios types: 'arraybuffer', 'document', 'json', 'text', 'stream'
 	const TEXT_TYPE = 'text';					// axios types: 'arraybuffer', 'document', 'json', 'text', 'stream'
+	const https = require('https');
 
 	return async (options, cb) => {
 		// ----------------------------------------------------------
 		// convert axios input arguments to request module input arguments
 		// ----------------------------------------------------------
+		let agentOptions = {};
 
 		// convert `body` -> `data`
 		if (options && options.body) {
@@ -51,6 +53,40 @@ module.exports = function (axios) {
 		// let grpc responses remain binary
 		if (options && options.json === false) {
 			options.responseType = ARRAY_BUFFER_TYPE;
+		}
+
+		//------------------------------------------------------------
+		// convert request style tls options to axios style
+		//------------------------------------------------------------
+		if (typeof options.rejectUnauthorized === 'boolean') {
+			agentOptions.rejectUnauthorized = options.rejectUnauthorized;
+		}
+		if (typeof options.requestCert === 'boolean') {
+			agentOptions.requestCert = options.requestCert;
+		}
+		if (typeof options.cert === 'string') {
+			agentOptions.cert = options.cert;
+		}
+		if (typeof options.key === 'string') {
+			agentOptions.key = options.key;
+		}
+		if (typeof options.ca === 'string') {
+			agentOptions.ca = options.ca;
+		}
+		if (typeof options.keepAlive === 'boolean') {
+			agentOptions.keepAlive = options.keepAlive;
+		}
+		if (typeof options.pfx === 'string') {
+			agentOptions.pfx = options.pfx;
+		}
+		if (typeof options.passphrase === 'string') {
+			agentOptions.passphrase = options.passphrase;
+		}
+		if (typeof options.secureOptions === 'number') {
+			agentOptions.secureOptions = options.secureOptions;
+		}
+		if (Object.keys(agentOptions).length > 0) {					// if we need a https agent, make one
+			options.httpsAgent = new https.Agent(agentOptions);
 		}
 
 

--- a/packages/stitch/docs/README.md
+++ b/packages/stitch/docs/README.md
@@ -3702,7 +3702,20 @@ stitch.getOSNChannel(opts, (err, data) => {
 	},
 	stitch_msg: "ok"       // error/success message for your req
 }
-// see https://github.com/hyperledger/fabric/blob/main/orderer/common/types/channelinfo.go
+/* below is pulled from fabric:
+// "active" - The orderer is active in the channel's consensus protocol, or following the cluster,
+// with block height > the join-block number. (Height is last block number +1).
+
+// "onboarding" - The orderer is catching up with the cluster by pulling blocks from other orderers,
+// with block height <= the join-block number.
+
+// "inactive" - The orderer is not storing any blocks for this channel.
+
+// "failed" - The last orderer operation against the channel failed.
+
+for more info on response:
+	https://github.com/hyperledger/fabric/blob/main/orderer/common/types/channelinfo.go
+*/
 ```
 
 <a name="joinOSNChannel"></a>


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
- fixes https requests that require mutual tls. Such as the orderer's channel participation apis. These APIs were failing because our `request` module replacement, `axios`, was not sending the client side tls cert.

- fixes our error response handling of the channel participation api `getOSNChannel`. will now correctly indicate an error occured.

