### PR TITLE
change config block doc's visibility to inbox after unjoinning the ch…

### DIFF
--- a/packages/apollo/src/components/ChannelModal/Wizard/OSNJoin/OSNJoin.js
+++ b/packages/apollo/src/components/ChannelModal/Wizard/OSNJoin/OSNJoin.js
@@ -152,6 +152,11 @@ class OSNJoin extends Component {
 					extra_consenter_data: nodes_arr,
 					tx_id: tx_id,
 				});
+
+				// then reload them to force cache update
+				await ConfigBlockApi.getAll({ cache: 'skip' });
+				await ConfigBlockApi.getAll({ cache: 'skip', visibility: 'all' });		// do both types
+
 				return apiResp;
 			} else {
 				return null;

--- a/packages/apollo/src/components/JoinOSNChannelModal/JoinOSNChannelModal.js
+++ b/packages/apollo/src/components/JoinOSNChannelModal/JoinOSNChannelModal.js
@@ -770,6 +770,10 @@ class JoinOSNChannelModal extends React.Component {
 			if (join_successes > 0 && tx_id) {
 				try {
 					await ConfigBlockApi.archive(tx_id);
+
+					// then reload them to force cache update
+					await ConfigBlockApi.getAll({ cache: 'skip' });
+					await ConfigBlockApi.getAll({ cache: 'skip', visibility: 'all' });		// do both types
 				} catch (e) {
 					Log.error(e);
 				}

--- a/packages/apollo/src/rest/ConfigBlockApi.js
+++ b/packages/apollo/src/rest/ConfigBlockApi.js
@@ -64,6 +64,11 @@ class ConfigBlockApi {
 	static async archive(tx_id) {
 		return await RestApi.put('/api/v3/configblocks/' + tx_id);
 	}
+
+	// remove OS from config block metadata
+	static async unarchive(tx_id, leaving_cluster_id) {
+		return await RestApi.patch('/api/v3/configblocks/' + tx_id, /*{ leaving_cluster_id: leaving_cluster_id }*/);
+	}
 }
 
 export default ConfigBlockApi;

--- a/packages/apollo/src/rest/RestApi.js
+++ b/packages/apollo/src/rest/RestApi.js
@@ -195,6 +195,10 @@ class RestApi {
 		return this.httpSendOld(url, 'PUT', body, headers);
 	}
 
+	static async patch(url, body, headers) {
+		return this.httpSendOld(url, 'PATCH', body, headers);
+	}
+
 	static async delete(url, body, headers) {
 		return this.httpSendOld(url, 'DELETE', body, headers);
 	}

--- a/packages/athena/routes/config_block_apis.js
+++ b/packages/athena/routes/config_block_apis.js
@@ -140,5 +140,32 @@ module.exports = (logger, ev, t) => {
 		});
 	}
 
+	//--------------------------------------------------
+	// Update a config block doc (change visibility from archive to inbox, happens when an OS nodes removes itself from the channel)
+	//--------------------------------------------------
+	app.patch('/api/v[123]/configblocks/:tx_id', t.middleware.verify_manage_action_session, (req, res) => {
+		unarchiveConfigBlock(req, res);
+	});
+	app.patch('/ak/api/v[123]/configblocks/:tx_id', t.middleware.verify_manage_action_ak, (req, res) => {
+		unarchiveConfigBlock(req, res);
+	});
+
+	function unarchiveConfigBlock(req, res) {
+		if (t.ot_misc.is_v2plus_route(req)) {
+			req._validate_path = '/ak/api/' + t.validate.pick_ver(req) + '/configblocks/{id}';
+			logger.debug('[pre-flight] setting validate route:', req._validate_path);
+		}
+
+		t.validate.request(req, res, null, () => {
+			t.config_blocks_lib.unarchiveBlockDoc(req, (err, ret) => {
+				if (err) {
+					return res.status(t.ot_misc.get_code(err)).json(err);
+				} else {
+					return res.status(200).json(ret);
+				}
+			});
+		});
+	}
+
 	return app;
 };


### PR DESCRIPTION


#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
- When unjoining an OS from a channel, the local config block document will be updated by changing it's visibility from `archive` to `inbox`. this will again show the pending-os-tile in the "Channels" page.
- also fixes some odd caching behavior with the pending-os-tile section of the "Channels" page

