### PR TITLE
reduce cache expiration from 2 minutes to 1.5 minutes

### DIFF
--- a/packages/athena/libs/proxy_lib.js
+++ b/packages/athena/libs/proxy_lib.js
@@ -369,7 +369,7 @@ module.exports = function (logger, ev, t) {
 				key_src: key_src,
 				cached_ts: Date.now(),								// remember when we stored it
 			};
-			t.proxy_cache.set(key, data2cache, 2 * 60);				// expiration is in sec
+			t.proxy_cache.set(key, data2cache, 90);				// expiration is in sec
 		}
 	};
 


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement (improvement to code, performance, etc)

#### Description
Lowers the cache expiration of component status APIs from 120 seconds to 90 seconds.

