### PR TITLE
change the prefixes found on exported files to FOC instead of IBP

### DIFF
--- a/packages/apollo/src/components/JoinOSNChannelModal/JoinOSNChannelModal.js
+++ b/packages/apollo/src/components/JoinOSNChannelModal/JoinOSNChannelModal.js
@@ -254,8 +254,8 @@ class JoinOSNChannelModal extends React.Component {
 		let link = document.getElementById('ibp-download-genesis-link2');
 		if (link) {
 			const d = new Date();
-			const dateStr = d.toLocaleDateString().split('/').join('-') + '-' + d.toLocaleTimeString().replace(/[:\s]/g, '');
-			let name = 'IBP_' + channel_name + '_genesis_' + dateStr + '.json';
+			const dateStr = d.toLocaleDateString().replace(/[/_]/g, '-') + '-' + d.toLocaleTimeString().replace(/[:\sAPM]/g, '');
+			let name = 'FOC.' + channel_name + '_genesis_' + dateStr + '.json';
 			const blob = new Blob([JSON.stringify(block, null, '\t')], { type: 'text/plain' });
 			let url = URL.createObjectURL(blob);
 			link.setAttribute('href', url);

--- a/packages/apollo/src/utils/helper.js
+++ b/packages/apollo/src/utils/helper.js
@@ -346,7 +346,9 @@ const Helper = {
 						document.querySelector('.side__panel--outer--container') || document.querySelector('.vertical__panel--outer--container') || document.body;
 					let link = document.createElement('a');
 					if (link.download !== undefined) {
-						let zipName = 'IBP_' + new Date().toLocaleDateString() + '_' + new Date().toLocaleTimeString() + '.zip';
+						const d = new Date();
+						const dateStr = d.toLocaleDateString().replace(/[/_]/g, '-') + '-' + d.toLocaleTimeString().replace(/[:\sAPM]/g, '');
+						let zipName = 'FOC.' + dateStr + '.zip';
 						let url = URL.createObjectURL(blob);
 						link.setAttribute('href', url);
 						link.setAttribute('download', zipName);


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Clean up

#### Description
zip files and json files that were downloaded used a legacy prefix of `IBP`, changing that to `FOC`. 
- example filename with this PR: `FOC.1-26-2024-42454.zip`


