### PR TITLE
Update audit log message while fail to adding peers to channel

### DIFF
--- a/packages/apollo/src/components/OrdererDetails/ChannelParticipationUnjoinModal.js
+++ b/packages/apollo/src/components/OrdererDetails/ChannelParticipationUnjoinModal.js
@@ -31,6 +31,7 @@ import { OrdererRestApi } from '../../rest/OrdererRestApi';
 import { NodeRestApi } from '../../rest/NodeRestApi';
 import ImportantBox from '../ImportantBox/ImportantBox';
 import ConfigBlockApi from '../../rest/ConfigBlockApi';
+import { EventsRestApi } from '../../rest/EventsRestApi';
 
 const SCOPE = 'ChannelParticipationUnjoinModal';
 
@@ -80,8 +81,10 @@ class ChannelParticipationUnjoinModal extends Component {
 				// TODO: consolidate error handling
 				// cannot remove: system channel exists
 				// cannot remove: channel does not exist
+				let errorStatus = '';
 				if (_.get(unjoinResp, 'error') !== undefined) {
 					this.props.updateState(SCOPE, { error: unjoinResp.error });
+					errorStatus = 'error';
 				} else {
 
 					// update the orderer as systemless
@@ -136,6 +139,7 @@ class ChannelParticipationUnjoinModal extends Component {
 					this.props.onComplete();
 					this.props.onClose();
 				}
+				EventsRestApi.sendUnJoinChannelEvent(this.props.channelInfo.name, this.props.myNodeList, errorStatus);
 			});
 		} catch (e) {
 			//error

--- a/packages/apollo/src/rest/EventsRestApi.js
+++ b/packages/apollo/src/rest/EventsRestApi.js
@@ -68,11 +68,11 @@ class EventsRestApi {
 		try {
 			const peer_names = peers.map(peer => {
 				return '"' + peer.display_name + '"';
-			});
+			}).join(', ');
 			EventsRestApi.recordActivity({
 				status: status === 'error' ? 'error' : 'success',
-				log: (peer_names.length > 1 ? 'peers' : 'peer') + ` ${peer_names.join(', ')} ` + (peer_names.length > 1 ? 'have' : 'has') + ` joined the channel "${channel_id}"`,
-				code: 200
+				log: `${peers.length > 1 ? 'peers' : 'peer'} ${peer_names} ${peers.length > 1 ? 'have' : 'has'} ${status === 'error' ? 'failed to ' : ''} joined the channel "${channel_id}"`,
+				code: status === 'error' ? 403 : 200
 			});
 		} catch (e) {
 			console.error('unable to record channel join', e);

--- a/packages/apollo/src/rest/EventsRestApi.js
+++ b/packages/apollo/src/rest/EventsRestApi.js
@@ -79,6 +79,21 @@ class EventsRestApi {
 		}
 	}
 
+	static async sendUnJoinChannelEvent(channel_id, peers, status) {
+		try {
+			const peer_names = peers.map(peer => {
+				return '"' + peer.display_name + '"';
+			}).join(', ');
+			EventsRestApi.recordActivity({
+				status: status === 'error' ? 'error' : 'success',
+				log: `${peers.length > 1 ? 'peers' : 'peer'} ${peer_names} ${peers.length > 1 ? 'have' : 'has'} ${status === 'error' ? 'failed to ' : ''} disconnect from the channel "${channel_id}"`,
+				code: status === 'error' ? 403 : 200
+			});
+		} catch (e) {
+			console.error('unable to record channel join', e);
+		}
+	}
+
 	static async sendInstallCCEvent(cc_name, cc_version, peer, status) {
 		try {
 			EventsRestApi.recordActivity({


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
<!--- Describe your changes in detail, including motivation. -->
- Update audit log message and status code while fail to add peers to channel.
- Add Audit log entry on Join Orderer peer to existing channel
- Add Audit log entry on disconnect orderer peer from channel

