### PR TITLE
fixes mustgather download button w/axios

### DIFF
--- a/packages/athena/libs/component_lib.js
+++ b/packages/athena/libs/component_lib.js
@@ -1108,6 +1108,7 @@ module.exports = function (logger, ev, t) {
 		// now that we have the data, rebuild the white list
 		function process_data(components, sig_docs, cb_built) {
 			const urls2add = {};									// grab all the urls we might add for any component, use map to avoid duplicates
+			urls2add[t.misc.fmt_url(ev.DEPLOYER_URL)] = true;
 
 			for (let i in components) {								// add urls from component docs
 				const comp_doc = components[i];

--- a/packages/athena/libs/patch_lib.js
+++ b/packages/athena/libs/patch_lib.js
@@ -47,7 +47,7 @@ module.exports = function (logger, ev, t) {
 		}*/
 
 		// name of the patch
-		'rebuild_safelist2': {
+		'rebuild_safelist3': {
 
 			// description of the patch, gets stored in patch doc
 			purpose: 'this patch rebuilds the hostname safe list to include ports',

--- a/packages/athena/libs/proxy_lib.js
+++ b/packages/athena/libs/proxy_lib.js
@@ -274,8 +274,6 @@ module.exports = function (logger, ev, t) {
 				let code = t.ot_misc.get_code(resp);
 				let headers;
 
-				//console.log('resp', resp.body ? resp.body.toString() : '-');
-
 				if (!t.ot_misc.is_error_code(code)) {									// errors are logged in retry req()
 					logger.info('[general proxy] - successful proxy response', code);
 				}

--- a/packages/athena/public/releaseNotes.json
+++ b/packages/athena/public/releaseNotes.json
@@ -1,7 +1,7 @@
 [
 	{
-		"version": "1.0.8-9",
-		"date": "29 Jan 2024",
+		"version": "1.0.8-10",
+		"date": "31 Jan 2024",
 		"description": [
 			{
 				"title": "Bug & security fixes",

--- a/packages/athena/routes/deployer_apis.js
+++ b/packages/athena/routes/deployer_apis.js
@@ -293,8 +293,17 @@ module.exports = (logger, ev, t) => {
 	// Proxy mustgather file download through to deployer
 	//--------------------------------------------------
 	app.get('/deployer/api/v3/instance/:siid/mustgather/download', t.middleware.verify_create_action_session, (req, res) => {
-		const downloadUrl = `${encodeURI(t.misc.format_url(ev.DEPLOYER_URL))}/api/v3/instance/${req.params.siid}/mustgather/download`;
-		t.request.get(downloadUrl).pipe(res);
+		req.originalUrl = `/proxy/${encodeURI(t.misc.format_url(ev.DEPLOYER_URL))}/api/v3/instance/${req.params.siid}/mustgather/download`;
+		t.proxy_lib.proxy_call(req, (ret) => {
+			if (ret.headers) {
+				res.set(ret.headers);
+			}
+			if (!ret.response) {
+				res.status(ret.statusCode).send();
+			} else {
+				res.status(ret.statusCode).send(ret.response);
+			}
+		});
 	});
 
 	//--------------------------------------------------

--- a/packages/athena/test/test-suites/routes/deployer_apis.test.js
+++ b/packages/athena/test/test-suites/routes/deployer_apis.test.js
@@ -1461,15 +1461,16 @@ describe('Deployer APIs', () => {
 						{
 							itStatement: 'should return a 200 status when download is called test_id=uhhxgc',
 							callFunction: () => {
-								tools.stubs.request = sinon.stub(tools, 'request');
-								const pipe = (res) => res.status(200).send('body');
-								tools.stubs.request.get = sinon.stub().returns({ pipe });
-
+								tools.stubs.get_code.restore();
+								tools.stubs.retry_req.callsArgWith(1, null, {
+									statusCode: 200,
+									body: JSON.stringify({ something: 'here' })
+								});
 							},
 							expectBlock: (res) => {
 								expect(res.status).to.equal(200);
-								expect(res.text).to.equal('body');
-								tools.stubs.request.restore();
+								expect(res.text).to.equal('{"something":"here"}');
+								tools.stubs.retry_req.restore();
 							}
 						},
 					]


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
Fixes the mustgather download zip button, the previous route for this download was using a `request.get` and a `pipe` method which are not available in our axios-request wrapper.

this fix does require rebuilding the URL allow list, which will happen on startup automatically

