### PR TITLE
fixes yaml parsing

### DIFF
--- a/packages/athena/libs/other_apis_lib.js
+++ b/packages/athena/libs/other_apis_lib.js
@@ -774,7 +774,7 @@ module.exports = function (logger, ev, t) {
 								if (process.env.CONFIGURE_FILE.indexOf('.json') >= 0) {
 									t.fs.writeFileSync(process.env.CONFIGURE_FILE, settings.config.data, 'utf8');	// if its json, simply write it
 								} else {
-									const yaml = t.yaml.safeDump(settings.config.data);			// if its a yaml, convert json to yaml first
+									const yaml = t.yaml.dump(settings.config.data);				// if its a yaml, convert json to yaml first
 									t.fs.writeFileSync(process.env.CONFIGURE_FILE, yaml, 'utf8');
 								}
 								logger.info('[settings edit] successfully wrote config file');
@@ -821,7 +821,7 @@ module.exports = function (logger, ev, t) {
 				components: openapi.components,
 			};
 			try {
-				return t.yaml.safeDump(swagger_file);				// convert json to yaml
+				return t.yaml.dump(swagger_file);				// convert json to yaml
 			} catch (e) {
 				logger.error('unable to work with swagger file:', e);
 			}

--- a/packages/athena/test/openapi/init_examples.js
+++ b/packages/athena/test/openapi/init_examples.js
@@ -202,7 +202,7 @@ function edit_swagger(ref, example, openapi_txt) {
 	let example_yaml = '';
 
 	try {
-		example_yaml = yaml.safeDump({
+		example_yaml = yaml.dump({
 			examples: {
 				response: {
 					value: example


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Bug fix

#### Description
YAML to JSON parsing was broken, `safeDump()` is not longer in the yaml library.

