### PR TITLE
add object-src to the csp header in all api responses

### DIFF
--- a/packages/athena/app.js
+++ b/packages/athena/app.js
@@ -647,7 +647,7 @@ function setHeaders(req, res, next) {
 	}
 	if (setNoCache) {																	// if asking for JSON, add no cache headers
 		no_cache_headers(res);
-		res.setHeader('Content-Security-Policy', 'default-src \'self\'; frame-ancestors \'none\'');	// suggestion by dsh
+		res.setHeader('Content-Security-Policy', 'default-src \'self\'; frame-ancestors \'none\'; object-src \'none\'');	// suggestion by dsh
 	} else {
 		if (ev && Array.isArray(ev.CSP_HEADER_VALUES)) {
 			res.setHeader('Content-Security-Policy', ev.CSP_HEADER_VALUES.join(';'));	// theres a bunch of things in here for the "Braze" tool


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement (security)

#### Description
- adding `object-src 'none'` to our CSP response header, this will be on all non-cached responses (cached responses already have it)

