### PR TITLE
remove init required input option in chaincode lifecycle 2.0

### DIFF
--- a/packages/apollo/src/components/ProposeChaincodeModal/ProposeChaincodeModal.js
+++ b/packages/apollo/src/components/ProposeChaincodeModal/ProposeChaincodeModal.js
@@ -54,7 +54,7 @@ class ProposeChaincodeModal extends React.Component {
 			pkg_id: null,
 			pkg_version: null,
 			parsing: false,
-			init_required: false,
+			init_required: false,							// 2024/02/22 - this is now always false, we do not want customers to set init_required as true
 			install_all_peers: true,
 			selected_peers: [...this.props.peerList],
 			policy: 'explicit',
@@ -219,7 +219,7 @@ class ProposeChaincodeModal extends React.Component {
 			private_data_json: this.props.private_data_json,
 			selected_peers: this.props.selected_peers,
 			configtxlator_url: this.props.configtxlator_url,
-			init_required: this.props.init_required ? this.props.init_required : false,
+			init_required: this.props.init_required,
 		};
 		if (this.props.existing_proposals && this.props.existing_proposals[this.props.pkg_id]) {
 			opts.tx_id = this.props.existing_proposals[this.props.pkg_id].tx_id;
@@ -532,29 +532,6 @@ class ProposeChaincodeModal extends React.Component {
 						},
 					]}
 				/>
-				<div className="ibp-form">
-					<div className="ibp-form-field">
-						<BlockchainTooltip noIcon
-							type="definition"
-							tooltipText={<span>{this.props.translate('init_required')}</span>}
-						>
-							{this.props.translate('init_required')}
-						</BlockchainTooltip>
-						<Toggle
-							id="toggle-init-required"
-							toggled={this.props.init_required}
-							onToggle={() => {
-								this.props.updateState(SCOPE, {
-									init_required: !this.props.init_required,
-								});
-							}}
-							onChange={() => {}}
-							aria-label={this.props.translate('init_required')}
-							labelA={this.props.translate('no')}
-							labelB={this.props.translate('yes')}
-						/>
-					</div>
-				</div>
 			</WizardStep>
 		);
 	}

--- a/packages/apollo/src/components/ProposeChaincodeModal/ProposeChaincodeModal.js
+++ b/packages/apollo/src/components/ProposeChaincodeModal/ProposeChaincodeModal.js
@@ -27,7 +27,6 @@ import { PeerRestApi } from '../../rest/PeerRestApi';
 import SignatureRestApi from '../../rest/SignatureRestApi';
 import Helper from '../../utils/helper';
 import PolicyHelper from '../../utils/policy';
-import BlockchainTooltip from '../BlockchainTooltip/BlockchainTooltip';
 import FileUploader from '../FileUploader/FileUploader';
 import Form from '../Form/Form';
 import ImportantBox from '../ImportantBox/ImportantBox';


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Cleanup update

#### Description
Removing the legacy `init_required` input option when making a chaincode definition (only applies to the 2.0 lifecycle). It will now always be `false`.

