### PR TITLE
fix version summary module, in the summary now it shows correct CA version in operator part

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You can use the following steps to provision a network using Fabric test-network
 * jq
 * docker
 * docker-compose (V2)
+* Node.js v18 or higher
 * _[WSL2](https://docs.microsoft.com/en-us/windows/wsl/install-win10) (Windows only)_
 
 ## Setup

--- a/packages/athena/libs/deployer_lib.js
+++ b/packages/athena/libs/deployer_lib.js
@@ -2135,12 +2135,6 @@ module.exports = function (logger, ev, t) {
 							default: false,
 							version: '1.4.12-11'
 						}
-					},
-					ca:{
-						'1.5.9': {
-							default: true,
-							version: '1.5.9'
-						}
 					}
 				}
 			});*/

--- a/packages/athena/libs/deployer_lib.js
+++ b/packages/athena/libs/deployer_lib.js
@@ -2135,6 +2135,12 @@ module.exports = function (logger, ev, t) {
 							default: false,
 							version: '1.4.12-11'
 						}
+					},
+					ca:{
+						'1.5.9': {
+							default: true,
+							version: '1.5.9'
+						}
 					}
 				}
 			});*/

--- a/packages/athena/libs/other_apis_lib.js
+++ b/packages/athena/libs/other_apis_lib.js
@@ -1004,7 +1004,7 @@ module.exports = function (logger, ev, t) {
 							const fab_type = types[i];
 							if (tmp && tmp[fab_type]) {
 								ret.operator.available_fabric_versions[fab_type] = [];
-								for (let ver in tmp.fab_type) {
+								for (let ver in tmp[fab_type]) {
 									ret.operator.available_fabric_versions[fab_type].push(t.misc.prettyPrintVersion(ver));
 								}
 							}

--- a/packages/athena/libs/other_apis_lib.js
+++ b/packages/athena/libs/other_apis_lib.js
@@ -1004,7 +1004,7 @@ module.exports = function (logger, ev, t) {
 							const fab_type = types[i];
 							if (tmp && tmp[fab_type]) {
 								ret.operator.available_fabric_versions[fab_type] = [];
-								for (let ver in tmp.peer) {
+								for (let ver in tmp.fab_type) {
 									ret.operator.available_fabric_versions[fab_type].push(t.misc.prettyPrintVersion(ver));
 								}
 							}


### PR DESCRIPTION
#### Type of change
- Bug fix

#### Description
<!--- Describe your changes in detail, including motivation. -->
When we download version summary from the settings in the console, in the operator part CA version was coming wrong. So, the changes will help to generate correct version of CA in the Version Summary Module of the console.
