### PR TITLE
2.0 ordering capability channel and fixes to failures

### DIFF
--- a/packages/apollo/test/cypress/e2e/features/04-CreateAndJoin2x_Org1AndOrg2.feature
+++ b/packages/apollo/test/cypress/e2e/features/04-CreateAndJoin2x_Org1AndOrg2.feature
@@ -88,6 +88,7 @@ Feature: Create and Join a 2.x channel
         And I provided 'channel2' for the 'Enter a name for your channel' input
         And I clicked the button with title 'Select from available ordering services'
         And I clicked the div with id 'downshift-0-item-0'
+		Then wait "3" seconds
         And I clicked the span with text 'Next'
         And I clicked the button with title 'Select MSP'
         And I clicked the div with text 'Org1 MSP (org1msp)'
@@ -108,16 +109,38 @@ Feature: Create and Join a 2.x channel
         And I clicked the span with text 'Next'
         And I clicked the div with id 'selectedApplicationCapability'
         And I clicked the div with text '2.0.0'
+        And I clicked the div with id 'selectedOrdererCapability'
+		And I clicked element with class '#selectedOrdererCapability > div > div:nth-child(2)'
         And I clicked the span with text 'Next'
         And I clicked the span with text 'Next'
         And I clicked the span with text 'Next'
         And I clicked the span with text 'Next'
         And I clicked the span with text 'Next'
-        And I clicked the span with text 'Next'
+        And I clicked the button with title 'Select the MSP'
+        And I clicked the div with text 'Ordering Service MSP (osmsp)'
+		And I clicked the span with text 'Next'
+		And I clicked the span with text 'Next'
         Then I clicked Create channel button
-        # And I clicked the button with text 'Create channel'
-        Then I should see a success toast with class '.bx--toast-notification__title' which says "You have successfully initiated a request to create channel2. Join a peer to this channel by clicking the pending channel tile below."
-        And the channel with name 'channel2' should have been created
+		Then wait "10" seconds
+		Then I should see a success toast with class '.bx--toast-notification__title' which says "You have successfully initiated a request to create channel2. This request requires the signature of an ordering service MSP. After the request has been signed and submitted, you will see a pending channel tile. Clicking on this tile will allow you to join a peer to the channel."
+		Then wait "5" seconds
+		# Approving New channel request
+		When I clicked the button with id 'ibp-header-signature-collection-icon'
+		And I clicked element with class '.ibp-signature-collection-notification-link'
+		Then wait "5" seconds
+		And I clicked the button with title 'Select identity to sign with'
+		And I clicked the div with text 'Ordering Service MSP Admin'
+		Then I clicked the button with id 'submit'
+		Then wait "5" seconds
+		When I clicked element with class '.ibp-signature-collection-notification-link'
+		Then wait "5" seconds
+		And I clicked the button with title 'Select MSP'
+		And I clicked the div with text 'Org2 MSP'
+		And I clicked the button with title 'Select an identity'
+		And I clicked the div with text 'Org2 MSP Admin'
+		Then I clicked the button with id 'submit'
+		Then wait "5" seconds
+		Then the element div with text 'channel2' should be visible on page
 
     Scenario: When joining a channel (channel2)
         And I am on the 'channels' page
@@ -127,3 +150,4 @@ Feature: Create and Join a 2.x channel
         And I clicked the span with text 'Peer Org2'
         When I clicked the button with id 'submit'
         Then I should see a success toast with class '.bx--toast-notification__title' which says "You have successfully joined channel2."
+		Then the element div with text 'channel2' should be visible on page

--- a/packages/apollo/test/cypress/e2e/features/09-BuildANetwork_Without_SysChannel.feature
+++ b/packages/apollo/test/cypress/e2e/features/09-BuildANetwork_Without_SysChannel.feature
@@ -138,6 +138,7 @@ Feature: Build a network without system channel
         And I provided 'channel5' for the 'Enter a name for your channel' input
         And I clicked the button with title 'Select from available ordering services'
         And I clicked the div with id 'downshift-0-item-0'
+		Then wait "5" seconds
         And I clicked the span with text 'Next'
         And I clicked the button with title 'Select MSP'
         And I clicked the div with text 'Org1 MSP (org1msp)'
@@ -158,6 +159,8 @@ Feature: Build a network without system channel
         And I clicked the span with text 'Next'
         And I clicked the div with id 'selectedApplicationCapability'
         And I clicked the div with text '2.0.0'
+        And I clicked the div with id 'selectedOrdererCapability'
+		And I clicked element with class '#selectedOrdererCapability > div > div:nth-child(2)'
         And I clicked the span with text 'Next'
         And I clicked the span with text 'Next'
         And I clicked the span with text 'Next'
@@ -172,6 +175,7 @@ Feature: Build a network without system channel
         When I clicked the button with id 'submit'
 		Then wait "5" seconds
         Then I should see a success toast with class '.bx--toast-notification__title' which says "You have successfully joined channel5."
+		Then wait "3" seconds
 
 	Scenario: Verify Orderer without system channel has joined channel
 		And I clicked the 'No_SysCh_OS' orderer

--- a/packages/apollo/test/cypress/e2e/features/12-AuditLog.feature
+++ b/packages/apollo/test/cypress/e2e/features/12-AuditLog.feature
@@ -82,8 +82,8 @@ Feature: Verify Audit Log functionality works as expected
 	Then I should see audit log row with text 'updating channel "testchainid" - MSP "osmsp"' and id 'audit-logs-log_title-0'
 	Then I should see audit log row with text 'success' and id 'audit-logs-outcome_title-0'
 	# creating channel "channel2" - MSP "org1msp"
-	When I provided 'creating channel "channel2" - MSP "org1msp"' for input field with id "1"
-	Then I should see audit log row with text 'creating channel "channel2" - MSP "org1msp"' and id 'audit-logs-log_title-0'
+	When I provided 'creating channel "channel1" - MSP "org1msp"' for input field with id "1"
+	Then I should see audit log row with text 'creating channel "channel1" - MSP "org1msp"' and id 'audit-logs-log_title-0'
 	Then I should see audit log row with text 'success' and id 'audit-logs-outcome_title-0'
 	Then I reload the page
 	# peers"Peer Org1", "Peer Org2" havejoined the channel "channel2"

--- a/packages/apollo/test/cypress/e2e/features/13-ConsoleAPI.feature
+++ b/packages/apollo/test/cypress/e2e/features/13-ConsoleAPI.feature
@@ -18,7 +18,6 @@ Feature: Verify Console APIs works as expected
 		Then I should see table with id "table-apikeys"
 		Then the element div with text 'managerAPIKey' should be visible on page
 
-
 	Scenario: Verify User can create new API key for writer and reader role
 		When I clicked the button with text 'Create an API key'
 		And I provided 'writerAPIKey' for the 'API key name' input
@@ -47,3 +46,17 @@ Feature: Verify Console APIs works as expected
 		And I clicked the button with id 'delete'
 		Then the element div with text 'There are no API keys yet' should be visible on page
 		Then I should see a success toast with class '.bx--toast-notification__title' which says "The selected API keys have been successfully removed."
+
+    Scenario: Search activity log for creating and deleting API key
+        When I clicked the div with id 'test__navigation--item--audit_logs'
+        Then I should see table with id 'table-audit_logs'
+        Then I should see div with id 'audit-logs'
+        And I provided 'creating api key' for input field with id "1"
+        Then I should see audit log row with text 'creating api key' and id 'audit-logs-log_title-0'
+        Then I should see audit log row with text 'POST:/api/v3/permissions/keys' and id 'audit-logs-api_title-0'
+        Then I should see audit log row with text 'success' and id 'audit-logs-outcome_title-0'
+        Then I reload the page
+        And I provided 'deleting api key' for input field with id "1"
+        Then I should see audit log row with text 'deleting api key' and id 'audit-logs-log_title-0'
+        Then I should see audit log row with text 'DELETE:/api/v3/permissions/{apikey}' and id 'audit-logs-api_title-0'
+        Then I should see audit log row with text 'success' and id 'audit-logs-outcome_title-0'

--- a/packages/apollo/test/cypress/support/commands.js
+++ b/packages/apollo/test/cypress/support/commands.js
@@ -36,9 +36,9 @@ Cypress.Commands.add('clickButton', (property, attributeValue) => {
   try{
     cy.wait(1000)
     if (property == "text"){
-        cy.get('button').contains(attributeValue).click()
+        cy.get('button').contains(attributeValue).should('be.visible').click()
     }else{
-      cy.get(`button[${property}="${attributeValue}"]`).click()
+      cy.get(`button[${property}="${attributeValue}"]`).should('be.visible').click()
     }
   }catch (err)
   {
@@ -47,7 +47,7 @@ Cypress.Commands.add('clickButton', (property, attributeValue) => {
 })
 
 //Enter text into input / text field
-Cypress.Commands.add('enterInput', (text, inputTitle) => {	
+Cypress.Commands.add('enterInput', (text, inputTitle) => {
 	try {
     cy.wait(500)
     cy.get(`input[title="${inputTitle}"]`).clear().type(text)

--- a/packages/apollo/test/cypress/support/commands.js
+++ b/packages/apollo/test/cypress/support/commands.js
@@ -36,9 +36,9 @@ Cypress.Commands.add('clickButton', (property, attributeValue) => {
   try{
     cy.wait(1000)
     if (property == "text"){
-        cy.get('button').contains(attributeValue).should('be.visible').click()
+        cy.get('button').contains(attributeValue).scrollIntoView().should('be.visible').click()
     }else{
-      cy.get(`button[${property}="${attributeValue}"]`).should('be.visible').click()
+      cy.get(`button[${property}="${attributeValue}"]`).scrollIntoView().should('be.visible').click()
     }
   }catch (err)
   {

--- a/packages/apollo/test/cypress/support/step_definitions/navigation_steps.js
+++ b/packages/apollo/test/cypress/support/step_definitions/navigation_steps.js
@@ -87,7 +87,7 @@ Then(/^the div with id (?:'|")(.*?)(?:'|") does not exist on page$/, value => {
 
 Given(/^the element (div|span) with text (?:'|")(.*?)(?:'|") should be visible on page$/, (property, value) => {
 	cy.wait(500)
-	cy.get(property).first().contains(value).should('be.visible')
+	cy.get(property).contains(value).should('be.visible')
 });
 
 Given(/^I clicked element with class (?:'|")(.*?)(?:'|")$/, (className) => {

--- a/packages/apollo/test/cypress/support/step_definitions/navigation_steps.js
+++ b/packages/apollo/test/cypress/support/step_definitions/navigation_steps.js
@@ -87,12 +87,12 @@ Then(/^the div with id (?:'|")(.*?)(?:'|") does not exist on page$/, value => {
 
 Given(/^the element (div|span) with text (?:'|")(.*?)(?:'|") should be visible on page$/, (property, value) => {
 	cy.wait(500)
-	cy.get(property).contains(value).should('be.visible')
+	cy.get(property).first().contains(value).should('be.visible')
 });
 
 Given(/^I clicked element with class (?:'|")(.*?)(?:'|")$/, (className) => {
 	cy.wait(500)
-	cy.get(className).should('be.visible').click()
+	cy.get(className).first().should('be.visible').click()
   });
 
 Then(/^the table row with id (?:'|")(.*?)(?:'|") does not exist on page$/, value => {

--- a/packages/apollo/test/cypress/support/step_definitions/notifcation_steps.js
+++ b/packages/apollo/test/cypress/support/step_definitions/notifcation_steps.js
@@ -47,6 +47,6 @@ Then(/^I should see a success toast with class (?:'|")(.*?)(?:'|") which says (?
 			}
 		}
 	}else{
-		cy.get(className, { timeout: 60000 }).contains(expectedMessage).should('be.visible')
+		cy.get(className, { timeout: 180000 }).contains(expectedMessage).should('be.visible')
 	}
 });


### PR DESCRIPTION
#### Type of change
- Test update

#### Description
1 - Updated Channel creation to use 2.0 ordering capability option
2 - Added new test to check for Audit logs for API key creation and deletion
3 - Fix as per pipeline failure