### PR TITLE
Removed DIND References from Deployer

### DIFF
--- a/packages/fabric-deployer/config/config.go
+++ b/packages/fabric-deployer/config/config.go
@@ -320,9 +320,7 @@ func verifyDefaultResources(resources *Resources) error {
 		if resources.Peer.Peer == nil {
 			return errors.New("no default resources set for Peer.Peer")
 		}
-		if resources.Peer.DinD == nil {
-			return errors.New("no default resources set for Peer.DinD")
-		}
+
 		if resources.Peer.GRPCProxy == nil {
 			return errors.New("no default resources set for Peer.GRPCProxy")
 		}

--- a/packages/fabric-deployer/config/config_struct.go
+++ b/packages/fabric-deployer/config/config_struct.go
@@ -154,15 +154,6 @@ type PeerImages struct {
 	// PeerDigest is the digest tag of the peer image
 	PeerDigest string `json:"peerDigest,omitempty"`
 
-	// DindImage is the name of the dind image
-	DindImage string `json:"dindImage,omitempty"`
-
-	// DindTag is the tag of the dind image
-	DindTag string `json:"dindTag,omitempty"`
-
-	// DindDigest is the digest tag of the dind image
-	DindDigest string `json:"dindDigest,omitempty"`
-
 	// GRPCWebImage is the name of the grpc web proxy image
 	GRPCWebImage string `json:"grpcwebImage,omitempty"`
 

--- a/packages/fabric-deployer/config/config_test.go
+++ b/packages/fabric-deployer/config/config_test.go
@@ -88,10 +88,6 @@ var _ = Describe("Config", func() {
 						Requests: res,
 						Limits:   res,
 					},
-					DinD: &corev1.ResourceRequirements{
-						Requests: res,
-						Limits:   res,
-					},
 					CouchDB: &corev1.ResourceRequirements{
 						Requests: res,
 						Limits:   res,
@@ -376,13 +372,6 @@ var _ = Describe("Config", func() {
 			err := config.VerifyDefaultStorageAndResource(defaults)
 			Expect(err).NotTo(BeNil())
 			Expect(err.Error()).To(Equal("no default resources set for Peer.Peer"))
-		})
-
-		It("returns an error if Peer.DinD resource values not configured", func() {
-			defaults.Resources.Peer.DinD = nil
-			err := config.VerifyDefaultStorageAndResource(defaults)
-			Expect(err).NotTo(BeNil())
-			Expect(err.Error()).To(Equal("no default resources set for Peer.DinD"))
 		})
 
 		It("returns an error if Peer.GRPCProxy resource values not configured", func() {

--- a/packages/fabric-deployer/deployer/components/peer/get.go
+++ b/packages/fabric-deployer/deployer/components/peer/get.go
@@ -144,11 +144,7 @@ func (peer *Peer) getResources(originalCR *current.IBPPeer, response *api.Respon
 			peerResources = append(peerResources, originalCR.Spec.Resources.GRPCProxy)
 		}
 	}
-	if util.GetMajorRelease(originalCR.Spec.FabricVersion) == 1 {
-		if originalCR.Spec.Resources.DinD != nil {
-			peerResources = append(peerResources, originalCR.Spec.Resources.DinD)
-		}
-	}
+
 	if util.GetMajorRelease(originalCR.Spec.FabricVersion) == 2 {
 		if originalCR.Spec.Resources != nil {
 			if originalCR.Spec.Resources.CCLauncher != nil {

--- a/packages/fabric-deployer/deployer/components/peer/get_test.go
+++ b/packages/fabric-deployer/deployer/components/peer/get_test.go
@@ -74,10 +74,6 @@ var _ = Describe("GET API", func() {
 				},
 				Resources: &cfg.Resources{
 					Peer: &current.PeerResources{
-						DinD: &corev1.ResourceRequirements{
-							Requests: res,
-							Limits:   res,
-						},
 						Peer: &corev1.ResourceRequirements{
 							Requests: res,
 							Limits:   res,

--- a/packages/fabric-deployer/deployer/components/peer/patch_test.go
+++ b/packages/fabric-deployer/deployer/components/peer/patch_test.go
@@ -73,10 +73,6 @@ var _ = Describe("Patch API", func() {
 				},
 				Resources: &cfg.Resources{
 					Peer: &current.PeerResources{
-						DinD: &corev1.ResourceRequirements{
-							Requests: res,
-							Limits:   res,
-						},
 						Peer: &corev1.ResourceRequirements{
 							Requests: res,
 							Limits:   res,

--- a/packages/fabric-deployer/deployer/components/peer/peer.go
+++ b/packages/fabric-deployer/deployer/components/peer/peer.go
@@ -108,10 +108,7 @@ func New(logger *zap.Logger, k8sClient Kube, ibpClient IBPOperatorClient, config
 
 func (peer *Peer) Images(version string) *current.PeerImages {
 	peerVersionedImages := peer.Config.Versions.Peer[version].Image
-	isVersion14X := false
-	if strings.HasPrefix(version, "1.4") {
-		isVersion14X = true
-	}
+
 	images := &current.PeerImages{}
 
 	images.PeerImage = peerVersionedImages.PeerImage
@@ -124,16 +121,12 @@ func (peer *Peer) Images(version string) *current.PeerImages {
 		images.HSMImage = peerVersionedImages.HSMImage
 	}
 
-	if isVersion14X {
-		images.DindImage = peerVersionedImages.DindImage
-	} else {
-		images.CCLauncherImage = peerVersionedImages.CCLauncherImage
-		images.FileTransferImage = peerVersionedImages.FileTransferImage
-		images.BuilderImage = peerVersionedImages.BuilderImage
-		images.GoEnvImage = peerVersionedImages.GoEnvImage
-		images.JavaEnvImage = peerVersionedImages.JavaEnvImage
-		images.NodeEnvImage = peerVersionedImages.NodeEnvImage
-	}
+	images.CCLauncherImage = peerVersionedImages.CCLauncherImage
+	images.FileTransferImage = peerVersionedImages.FileTransferImage
+	images.BuilderImage = peerVersionedImages.BuilderImage
+	images.GoEnvImage = peerVersionedImages.GoEnvImage
+	images.JavaEnvImage = peerVersionedImages.JavaEnvImage
+	images.NodeEnvImage = peerVersionedImages.NodeEnvImage
 
 	if peer.Config.UseTags == nil || *peer.Config.UseTags == true {
 		// Set the tags
@@ -146,16 +139,14 @@ func (peer *Peer) Images(version string) *current.PeerImages {
 		if peerVersionedImages.HSMImage != "" {
 			images.HSMTag = peerVersionedImages.HSMTag
 		}
-		if isVersion14X {
-			images.DindTag = peerVersionedImages.DindTag
-		} else {
-			images.CCLauncherTag = peerVersionedImages.CCLauncherTag
-			images.FileTransferTag = peerVersionedImages.FileTransferTag
-			images.BuilderTag = peerVersionedImages.BuilderTag
-			images.GoEnvTag = peerVersionedImages.GoEnvTag
-			images.JavaEnvTag = peerVersionedImages.JavaEnvTag
-			images.NodeEnvTag = peerVersionedImages.NodeEnvTag
-		}
+
+		images.CCLauncherTag = peerVersionedImages.CCLauncherTag
+		images.FileTransferTag = peerVersionedImages.FileTransferTag
+		images.BuilderTag = peerVersionedImages.BuilderTag
+		images.GoEnvTag = peerVersionedImages.GoEnvTag
+		images.JavaEnvTag = peerVersionedImages.JavaEnvTag
+		images.NodeEnvTag = peerVersionedImages.NodeEnvTag
+
 	} else {
 		// set the digests to the tags
 		images.PeerInitTag = peerVersionedImages.PeerInitDigest
@@ -168,16 +159,13 @@ func (peer *Peer) Images(version string) *current.PeerImages {
 			images.HSMTag = peerVersionedImages.HSMDigest
 		}
 
-		if isVersion14X {
-			images.DindTag = peerVersionedImages.DindDigest
-		} else {
-			images.CCLauncherTag = peerVersionedImages.CCLauncherDigest
-			images.FileTransferTag = peerVersionedImages.FileTransferDigest
-			images.BuilderTag = peerVersionedImages.BuilderDigest
-			images.GoEnvTag = peerVersionedImages.GoEnvDigest
-			images.JavaEnvTag = peerVersionedImages.JavaEnvDigest
-			images.NodeEnvTag = peerVersionedImages.NodeEnvDigest
-		}
+		images.CCLauncherTag = peerVersionedImages.CCLauncherDigest
+		images.FileTransferTag = peerVersionedImages.FileTransferDigest
+		images.BuilderTag = peerVersionedImages.BuilderDigest
+		images.GoEnvTag = peerVersionedImages.GoEnvDigest
+		images.JavaEnvTag = peerVersionedImages.JavaEnvDigest
+		images.NodeEnvTag = peerVersionedImages.NodeEnvDigest
+
 	}
 	return images
 }
@@ -441,10 +429,6 @@ func (peer *Peer) GetResources(defaults current.PeerResources, override *current
 			overrideResources(resources.Peer, initResources(override.Peer))
 		}
 
-		if override.DinD != nil {
-			overrideResources(resources.DinD, initResources(override.DinD))
-		}
-
 		if strings.ToLower(statedb) == "couchdb" {
 			if override.CouchDB != nil {
 				overrideResources(resources.CouchDB, initResources(override.CouchDB))
@@ -461,10 +445,8 @@ func (peer *Peer) GetResources(defaults current.PeerResources, override *current
 			overrideResources(resources.Init, initResources(override.Init))
 		}
 
-		// Fabric version 2.x does not require DinD
+		// Fabric version 2.x does not require
 		if util.GetMajorRelease(fabricVersion) == 2 {
-			resources.DinD = nil
-
 			if override.CCLauncher != nil {
 				overrideResources(resources.CCLauncher, initResources(override.CCLauncher))
 			}
@@ -503,22 +485,6 @@ func (peer *Peer) GetUpdateResources(current, override *current.PeerResources) (
 			}
 			if override.Peer.Limits != nil {
 				resources.Peer.Limits = override.Peer.Limits
-			}
-		}
-
-		if override.DinD != nil {
-			if override.DinD.Requests == nil {
-				override.DinD.Requests = override.DinD.Limits
-			}
-			if override.DinD.Limits == nil {
-				override.DinD.Limits = override.DinD.Requests
-			}
-
-			if override.DinD.Requests != nil {
-				resources.DinD.Requests = override.DinD.Requests
-			}
-			if override.DinD.Limits != nil {
-				resources.DinD.Limits = override.DinD.Limits
 			}
 		}
 
@@ -640,14 +606,11 @@ func (peer *Peer) GetIndividualResources(individualResources string, allResource
 	if allResources.Init != nil {
 		resources.Init = allResources.Init
 	}
-	if allResources.DinD != nil {
-		resources.DinD = allResources.DinD
-	}
+
 	if util.GetMajorRelease(fabricVersion) == 2 {
 		if allResources.CCLauncher != nil {
 			resources.CCLauncher = allResources.CCLauncher
 		}
-		resources.DinD = nil
 	}
 	if allResources.Enroller != nil {
 		resources.Enroller = allResources.Enroller

--- a/packages/fabric-deployer/deployer/components/peer/peer_test.go
+++ b/packages/fabric-deployer/deployer/components/peer/peer_test.go
@@ -69,10 +69,6 @@ var _ = Describe("Peer", func() {
 		res[corev1.ResourceCPU] = resource.MustParse("1")
 		res[corev1.ResourceMemory] = resource.MustParse("1Mi")
 		resources = &current.PeerResources{
-			DinD: &corev1.ResourceRequirements{
-				Requests: res,
-				Limits:   res,
-			},
 			CouchDB: &corev1.ResourceRequirements{
 				Requests: res,
 				Limits:   res,
@@ -188,10 +184,6 @@ var _ = Describe("Peer", func() {
 						Requests: res,
 						Limits:   res,
 					},
-					DinD: &corev1.ResourceRequirements{
-						Requests: res,
-						Limits:   res,
-					},
 					CouchDB: &corev1.ResourceRequirements{
 						Requests: res,
 						Limits:   res,
@@ -296,10 +288,6 @@ var _ = Describe("Peer", func() {
 							Requests: res,
 							Limits:   res,
 						},
-						DinD: &corev1.ResourceRequirements{
-							Requests: res,
-							Limits:   res,
-						},
 						GRPCProxy: &corev1.ResourceRequirements{
 							Requests: res,
 							Limits:   res,
@@ -370,7 +358,6 @@ var _ = Describe("Peer", func() {
 				Resources: &current.PeerResources{
 					Peer:       &corev1.ResourceRequirements{},
 					GRPCProxy:  &corev1.ResourceRequirements{},
-					DinD:       &corev1.ResourceRequirements{},
 					CouchDB:    &corev1.ResourceRequirements{},
 					CCLauncher: &corev1.ResourceRequirements{},
 					Enroller:   &corev1.ResourceRequirements{},
@@ -455,10 +442,6 @@ var _ = Describe("Peer", func() {
 				res[corev1.ResourceCPU] = resource.MustParse("1")
 				res[corev1.ResourceMemory] = resource.MustParse("1Mi")
 				resources := &current.PeerResources{
-					DinD: &corev1.ResourceRequirements{
-						Requests: res,
-						Limits:   res,
-					},
 					CouchDB: &corev1.ResourceRequirements{
 						Requests: res,
 						Limits:   res,
@@ -560,7 +543,6 @@ var _ = Describe("Peer", func() {
 				Init:       currentResources.DeepCopy(),
 				Peer:       currentResources.DeepCopy(),
 				GRPCProxy:  currentResources.DeepCopy(),
-				DinD:       currentResources.DeepCopy(),
 				CouchDB:    currentResources.DeepCopy(),
 				CCLauncher: currentResources.DeepCopy(),
 				Enroller:   currentResources.DeepCopy(),
@@ -578,7 +560,6 @@ var _ = Describe("Peer", func() {
 				Init:       overrideResources.DeepCopy(),
 				Peer:       overrideResources.DeepCopy(),
 				GRPCProxy:  overrideResources.DeepCopy(),
-				DinD:       overrideResources.DeepCopy(),
 				CouchDB:    overrideResources.DeepCopy(),
 				CCLauncher: overrideResources.DeepCopy(),
 				Enroller:   overrideResources.DeepCopy(),
@@ -597,8 +578,6 @@ var _ = Describe("Peer", func() {
 			Expect(finalRes.Peer.Limits).To(Equal(overrideResources.Limits))
 			Expect(finalRes.GRPCProxy.Requests).To(Equal(overrideResources.Requests))
 			Expect(finalRes.GRPCProxy.Limits).To(Equal(overrideResources.Limits))
-			Expect(finalRes.DinD.Requests).To(Equal(overrideResources.Requests))
-			Expect(finalRes.DinD.Limits).To(Equal(overrideResources.Limits))
 			Expect(finalRes.CouchDB.Requests).To(Equal(overrideResources.Requests))
 			Expect(finalRes.CouchDB.Limits).To(Equal(overrideResources.Limits))
 			Expect(finalRes.CCLauncher.Requests).To(Equal(overrideResources.Requests))
@@ -612,7 +591,6 @@ var _ = Describe("Peer", func() {
 			overridePeerres.Init.Limits = nil
 			overridePeerres.Peer.Limits = nil
 			overridePeerres.GRPCProxy.Limits = nil
-			overridePeerres.DinD.Limits = nil
 			overridePeerres.CouchDB.Limits = nil
 			overridePeerres.CCLauncher.Limits = nil
 			overridePeerres.Enroller.Limits = nil
@@ -628,8 +606,6 @@ var _ = Describe("Peer", func() {
 			Expect(finalRes.Peer.Limits).To(Equal(overrideResources.Limits))
 			Expect(finalRes.GRPCProxy.Requests).To(Equal(overrideResources.Requests))
 			Expect(finalRes.GRPCProxy.Limits).To(Equal(overrideResources.Limits))
-			Expect(finalRes.DinD.Requests).To(Equal(overrideResources.Requests))
-			Expect(finalRes.DinD.Limits).To(Equal(overrideResources.Limits))
 			Expect(finalRes.CouchDB.Requests).To(Equal(overrideResources.Requests))
 			Expect(finalRes.CouchDB.Limits).To(Equal(overrideResources.Limits))
 			Expect(finalRes.CCLauncher.Requests).To(Equal(overrideResources.Requests))
@@ -643,7 +619,6 @@ var _ = Describe("Peer", func() {
 			overridePeerres.Init.Requests = nil
 			overridePeerres.Peer.Requests = nil
 			overridePeerres.GRPCProxy.Requests = nil
-			overridePeerres.DinD.Requests = nil
 			overridePeerres.CouchDB.Requests = nil
 			overridePeerres.CCLauncher.Requests = nil
 			overridePeerres.Enroller.Requests = nil
@@ -659,8 +634,6 @@ var _ = Describe("Peer", func() {
 			Expect(finalRes.Peer.Limits).To(Equal(overrideResources.Limits))
 			Expect(finalRes.GRPCProxy.Requests).To(Equal(overrideResources.Requests))
 			Expect(finalRes.GRPCProxy.Limits).To(Equal(overrideResources.Limits))
-			Expect(finalRes.DinD.Requests).To(Equal(overrideResources.Requests))
-			Expect(finalRes.DinD.Limits).To(Equal(overrideResources.Limits))
 			Expect(finalRes.CouchDB.Requests).To(Equal(overrideResources.Requests))
 			Expect(finalRes.CouchDB.Limits).To(Equal(overrideResources.Limits))
 			Expect(finalRes.CCLauncher.Requests).To(Equal(overrideResources.Requests))
@@ -691,7 +664,6 @@ var _ = Describe("Peer", func() {
 				Init:       currentResources.DeepCopy(),
 				Peer:       currentResources.DeepCopy(),
 				GRPCProxy:  currentResources.DeepCopy(),
-				DinD:       currentResources.DeepCopy(),
 				CouchDB:    currentResources.DeepCopy(),
 				CCLauncher: currentResources.DeepCopy(),
 				Enroller:   currentResources.DeepCopy(),
@@ -714,7 +686,6 @@ var _ = Describe("Peer", func() {
 				Init:       overrideResources.DeepCopy(),
 				Peer:       overrideResources.DeepCopy(),
 				GRPCProxy:  overrideResources.DeepCopy(),
-				DinD:       overrideResources.DeepCopy(),
 				CouchDB:    overrideResources.DeepCopy(),
 				CCLauncher: overrideResources.DeepCopy(),
 				Enroller:   overrideResources.DeepCopy(),
@@ -740,7 +711,6 @@ var _ = Describe("Peer", func() {
 					Expect(finalRes.Enroller.Limits).To(Equal(overrideResources.Limits))
 					Expect(finalRes.HSMDaemon.Requests).To(Equal(overrideResources.Requests))
 					Expect(finalRes.HSMDaemon.Limits).To(Equal(overrideResources.Limits))
-					Expect(finalRes.DinD).To(BeNil())
 				}
 
 				It("Should return the override resources over if limits and requests are set", func() {
@@ -755,7 +725,6 @@ var _ = Describe("Peer", func() {
 					overridePeerres.Init.Limits = nil
 					overridePeerres.Peer.Limits = nil
 					overridePeerres.GRPCProxy.Limits = nil
-					overridePeerres.DinD.Limits = nil
 					overridePeerres.CouchDB.Limits = nil
 					overridePeerres.CCLauncher.Limits = nil
 					overridePeerres.Enroller.Limits = nil
@@ -772,7 +741,6 @@ var _ = Describe("Peer", func() {
 					overridePeerres.Init.Requests = nil
 					overridePeerres.Peer.Requests = nil
 					overridePeerres.GRPCProxy.Requests = nil
-					overridePeerres.DinD.Requests = nil
 					overridePeerres.CouchDB.Requests = nil
 					overridePeerres.CCLauncher.Requests = nil
 					overridePeerres.Enroller.Requests = nil
@@ -800,7 +768,6 @@ var _ = Describe("Peer", func() {
 					Expect(finalRes.Enroller.Limits).To(Equal(overrideResources.Limits))
 					Expect(finalRes.HSMDaemon.Requests).To(Equal(overrideResources.Requests))
 					Expect(finalRes.HSMDaemon.Limits).To(Equal(overrideResources.Limits))
-					Expect(finalRes.DinD).To(BeNil())
 					Expect(finalRes.CouchDB).To(BeNil())
 				}
 
@@ -816,7 +783,6 @@ var _ = Describe("Peer", func() {
 					overridePeerres.Init.Limits = nil
 					overridePeerres.Peer.Limits = nil
 					overridePeerres.GRPCProxy.Limits = nil
-					overridePeerres.DinD.Limits = nil
 					overridePeerres.CouchDB.Limits = nil
 					overridePeerres.CCLauncher.Limits = nil
 					overridePeerres.Enroller.Limits = nil
@@ -833,7 +799,6 @@ var _ = Describe("Peer", func() {
 					overridePeerres.Init.Requests = nil
 					overridePeerres.Peer.Requests = nil
 					overridePeerres.GRPCProxy.Requests = nil
-					overridePeerres.DinD.Requests = nil
 					overridePeerres.CouchDB.Requests = nil
 					overridePeerres.CCLauncher.Requests = nil
 					overridePeerres.Enroller.Requests = nil
@@ -859,8 +824,6 @@ var _ = Describe("Peer", func() {
 					Expect(finalRes.GRPCProxy.Limits).To(Equal(overrideResources.Limits))
 					Expect(finalRes.CouchDB.Requests).To(Equal(overrideResources.Requests))
 					Expect(finalRes.CouchDB.Limits).To(Equal(overrideResources.Limits))
-					Expect(finalRes.DinD.Requests).To(Equal(overrideResources.Requests))
-					Expect(finalRes.DinD.Limits).To(Equal(overrideResources.Limits))
 					Expect(finalRes.Enroller.Requests).To(Equal(overrideResources.Requests))
 					Expect(finalRes.Enroller.Limits).To(Equal(overrideResources.Limits))
 					Expect(finalRes.HSMDaemon.Requests).To(Equal(overrideResources.Requests))
@@ -880,7 +843,6 @@ var _ = Describe("Peer", func() {
 					overridePeerres.Init.Limits = nil
 					overridePeerres.Peer.Limits = nil
 					overridePeerres.GRPCProxy.Limits = nil
-					overridePeerres.DinD.Limits = nil
 					overridePeerres.CouchDB.Limits = nil
 					overridePeerres.CCLauncher.Limits = nil
 					overridePeerres.Enroller.Limits = nil
@@ -897,7 +859,6 @@ var _ = Describe("Peer", func() {
 					overridePeerres.Init.Requests = nil
 					overridePeerres.Peer.Requests = nil
 					overridePeerres.GRPCProxy.Requests = nil
-					overridePeerres.DinD.Requests = nil
 					overridePeerres.CouchDB.Requests = nil
 					overridePeerres.CCLauncher.Requests = nil
 					overridePeerres.Enroller.Requests = nil
@@ -919,8 +880,6 @@ var _ = Describe("Peer", func() {
 					Expect(finalRes.Peer.Limits).To(Equal(overrideResources.Limits))
 					Expect(finalRes.GRPCProxy.Requests).To(Equal(overrideResources.Requests))
 					Expect(finalRes.GRPCProxy.Limits).To(Equal(overrideResources.Limits))
-					Expect(finalRes.DinD.Requests).To(Equal(overrideResources.Requests))
-					Expect(finalRes.DinD.Limits).To(Equal(overrideResources.Limits))
 					Expect(finalRes.Enroller.Requests).To(Equal(overrideResources.Requests))
 					Expect(finalRes.Enroller.Limits).To(Equal(overrideResources.Limits))
 					Expect(finalRes.HSMDaemon.Requests).To(Equal(overrideResources.Requests))
@@ -941,7 +900,6 @@ var _ = Describe("Peer", func() {
 					overridePeerres.Init.Limits = nil
 					overridePeerres.Peer.Limits = nil
 					overridePeerres.GRPCProxy.Limits = nil
-					overridePeerres.DinD.Limits = nil
 					overridePeerres.CouchDB.Limits = nil
 					overridePeerres.CCLauncher.Limits = nil
 					overridePeerres.Enroller.Limits = nil
@@ -958,7 +916,6 @@ var _ = Describe("Peer", func() {
 					overridePeerres.Init.Requests = nil
 					overridePeerres.Peer.Requests = nil
 					overridePeerres.GRPCProxy.Requests = nil
-					overridePeerres.DinD.Requests = nil
 					overridePeerres.CouchDB.Requests = nil
 					overridePeerres.CCLauncher.Requests = nil
 					overridePeerres.Enroller.Requests = nil

--- a/packages/fabric-deployer/deployer/components/peer/update_test.go
+++ b/packages/fabric-deployer/deployer/components/peer/update_test.go
@@ -73,10 +73,6 @@ var _ = Describe("Update API", func() {
 				},
 				Resources: &cfg.Resources{
 					Peer: &current.PeerResources{
-						DinD: &corev1.ResourceRequirements{
-							Requests: res,
-							Limits:   res,
-						},
 						Peer: &corev1.ResourceRequirements{
 							Requests: res,
 							Limits:   res,

--- a/packages/fabric-deployer/deployer/deployer_test.go
+++ b/packages/fabric-deployer/deployer/deployer_test.go
@@ -56,7 +56,6 @@ var _ = Describe("Deployer", func() {
 					},
 					Peer: &current.PeerResources{
 						Peer:      &corev1.ResourceRequirements{},
-						DinD:      &corev1.ResourceRequirements{},
 						CouchDB:   &corev1.ResourceRequirements{},
 						GRPCProxy: &corev1.ResourceRequirements{},
 					},

--- a/packages/fabric-deployer/docs/v3_apis.md
+++ b/packages/fabric-deployer/docs/v3_apis.md
@@ -220,7 +220,6 @@ a newer version.
                 "peer": {},
                 "couchdb": {},              // only passed if statedb is set to couchdb
                 "proxy": {},
-                "dind": {},                 // only for 1.4.x peer
                 "chaincodelauncher": {}     // only for 2.x peer
             },
             "storage": {     // optional, see storage limits
@@ -356,7 +355,6 @@ Useful documentation for possible updates:
                 "peer": {},
                 "couchdb": {},
                 "proxy": {},
-                "dind": {},
             },
             "configoverride": {},           // optional, core yaml configs
             "hsm": {                        // optional, hsm  params change  (proxy configs)

--- a/packages/fabric-deployer/docs/v3_responses/versions_all.json
+++ b/packages/fabric-deployer/docs/v3_responses/versions_all.json
@@ -23,8 +23,6 @@
             "peerInitTag": "sha256:75a24e088353294113ca399c64a6ea918435dd59f2839a3bb6af2b95135e236b",
             "peerImage": "us.icr.io/ibp-temp/ibp-peer",
             "peerTag": "sha256:59dd67649a2b920108f806062edadc85093195b684962512a210773ce17ec81c",
-            "dindImage": "us.icr.io/ibp-temp/ibp-dind",
-            "dindTag": "sha256:bd83e2a0eb012ffd456516b007a9a7c4cbd5aac3a83acd181a3bcc38f1522155",
             "grpcwebImage": "us.icr.io/ibp-temp/ibp-grpcweb",
             "grpcwebTag": "sha256:81e333a50cba5302bb20261838b7e47e9619fb9c79b2b3e47d9da13b7f2affd9",
             "couchdbImage": "us.icr.io/ibp-temp/ibp-couchdb",

--- a/packages/fabric-deployer/docs/v3_responses/versions_peer.json
+++ b/packages/fabric-deployer/docs/v3_responses/versions_peer.json
@@ -8,8 +8,6 @@
           "peerInitTag": "sha256:75a24e088353294113ca399c64a6ea918435dd59f2839a3bb6af2b95135e236b",
           "peerImage": "us.icr.io/ibp-temp/ibp-peer",
           "peerTag": "sha256:59dd67649a2b920108f806062edadc85093195b684962512a210773ce17ec81c",
-          "dindImage": "us.icr.io/ibp-temp/ibp-dind",
-          "dindTag": "sha256:bd83e2a0eb012ffd456516b007a9a7c4cbd5aac3a83acd181a3bcc38f1522155",
           "grpcwebImage": "us.icr.io/ibp-temp/ibp-grpcweb",
           "grpcwebTag": "sha256:81e333a50cba5302bb20261838b7e47e9619fb9c79b2b3e47d9da13b7f2affd9",
           "couchdbImage": "us.icr.io/ibp-temp/ibp-couchdb",

--- a/packages/fabric-deployer/sampleconfigs/local-config.yaml
+++ b/packages/fabric-deployer/sampleconfigs/local-config.yaml
@@ -108,13 +108,6 @@ defaults:
         limits:
           cpu: 2
           memory: 4Gi
-      dind:
-        requests:
-          cpu: 20m
-          memory: 1Gi
-        limits:
-          cpu: 2
-          memory: 4Gi
       proxy:
         requests:
           cpu: 30m


### PR DESCRIPTION
#### Type of change

- Improvement (Code Cleanup)

#### Description
We had references of DIND in the deployer code which is deprecated and no longer needed in fabric 2x. Hence removed all the references of DIND from codebase
