### PR TITLE
added condition for migrated component to return os style urls

### DIFF
--- a/packages/athena/libs/component_lib.js
+++ b/packages/athena/libs/component_lib.js
@@ -1679,7 +1679,7 @@ module.exports = function (logger, ev, t) {
 		if (comp_doc) {
 
 			// if its been migrated use the legacy routes
-			if (comp_doc.migrated_from === ev.STR.LOCATION_IBP_SAAS) {
+			if (comp_doc.migrated_from === ev.STR.LOCATION_IBP_SAAS && comp_doc.preferred_url !== ev.STR.OPEN_SOURCE_STYLE) {
 				if (comp_doc.type === ev.STR.CA && comp_doc.api_url_saas) {
 					return comp_doc.api_url_saas + '/cainfo';			// CA's use this route
 				} else if (comp_doc.operations_url_saas && (comp_doc.type === ev.STR.ORDERER || comp_doc.type === ev.STR.PEER)) {


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- New feature

#### Description
<!--- Describe your changes in detail, including motivation. -->

the console currently uses the field migrated_from="ibm_saas" to decide if it should use the legacy (saas) set of urls to communicate to the component, or the opensource-operator styled urls. this change allows a new field called preferred_url to be set (per component) to "os", which would allow a migrated(saas) component to return with the open-source style of urls.

> "preferred_url" - The style/format of a url to return for a migrated component. Does not apply to non-migrated components. Set to "os" to return open-source operator urls for these field: api_url, operations_url and osnadmin_url. Otherwise migrated components will return the legacy ("saas") style urls.

- effects apis like:
    - get-component
    - get-all-components

