### PR TITLE
Revert to UBI8 for now.

### DIFF
--- a/docker/console/Dockerfile
+++ b/docker/console/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/nodejs-18 as client
+FROM registry.access.redhat.com/ubi8/nodejs-18 as client
 ENV STITCH_DIR=/home/stitch
 ENV APOLLO_DIR=/home/apollo
 
@@ -52,7 +52,7 @@ RUN ls -l $APOLLO_DIR/build
 # ----------------------------
 # ------- Server Setup -------
 # ----------------------------
-FROM registry.access.redhat.com/ubi9/nodejs-18 as server
+FROM registry.access.redhat.com/ubi8/nodejs-18 as server
 ENV STITCH_DIR=/home/stitch
 ENV APOLLO_DIR=/home/apollo
 ENV SERVER_HOME=/home/athena


### PR DESCRIPTION
It's premature to move to UBI-9 at the moment and causes too many issues with build process.  The other changes can stay and remain helpful improvements.