### PR TITLE
fix reader writer unable to get bearer token details

### DIFF
--- a/packages/athena/libs/middleware/middleware.js
+++ b/packages/athena/libs/middleware/middleware.js
@@ -93,6 +93,7 @@ module.exports = function (logger, ev, t) {
 	// manage api keys (not valid on SaaS)
 	exports.verify_apiKey_action_session = [eTrack, blockReadOnlyMode, needApiKeyAction, checkAuthentication, permitAction];
 	exports.verify_apiKey_action_ak = [eTrack, blockReadOnlyMode, needApiKeyAction, allowAkToDoAction];
+	exports.verify_apiKey_action_ak_view = [eTrack, blockReadOnlyMode, needViewAction, allowAkToDoAction];
 
 	// manage generate bearer token using api key
 	exports.verify_apiKey_bearer_action_session = [eTrack, blockReadOnlyMode, needViewAction, checkAuthentication, permitAction];

--- a/packages/athena/routes/permission_apis.js
+++ b/packages/athena/routes/permission_apis.js
@@ -323,7 +323,7 @@ module.exports = function (logger, ev, t) {
 			}
 		});
 	});
-	app.get('/ak/api/v3/identity/token/:id', t.middleware.verify_apiKey_action_ak, (req, res) => {
+	app.get('/ak/api/v3/identity/token/:id', t.middleware.verify_apiKey_action_ak_view, (req, res) => {
 		t.permissions_lib.get_access_token(req.params.id, (err, ret) => {
 			if (err) {
 				return res.status(t.ot_misc.get_code(err)).json(err);


### PR DESCRIPTION
#### Type of change
- Bug fix
#### Description
Reader and Writer role user is now able to get bearer token details for the token generated with their API Key

