### PR TITLE
Update ubi8 to nodejs20

### DIFF
--- a/docker/console/Dockerfile
+++ b/docker/console/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/nodejs-18 as client
+FROM registry.access.redhat.com/ubi8/nodejs-20 as client
 ENV STITCH_DIR=/home/stitch
 ENV APOLLO_DIR=/home/apollo
 
@@ -52,7 +52,7 @@ RUN ls -l $APOLLO_DIR/build
 # ----------------------------
 # ------- Server Setup -------
 # ----------------------------
-FROM registry.access.redhat.com/ubi8/nodejs-18 as server
+FROM registry.access.redhat.com/ubi8/nodejs-20 as server
 ENV STITCH_DIR=/home/stitch
 ENV APOLLO_DIR=/home/apollo
 ENV SERVER_HOME=/home/athena


### PR DESCRIPTION
Update ubi8 to nodejs20
registry.access.redhat.com/ubi8/nodejs-20

#### Type of change
nodejs 20 update

#### Description
Update ubi8 to nodejs20
registry.access.redhat.com/ubi8/nodejs-20
