### PR TITLE
fix for CVE-2024-41110

### DIFF
--- a/packages/apollo/package-lock.json
+++ b/packages/apollo/package-lock.json
@@ -6353,7 +6353,7 @@
 				"browserify-rsa": "^4.1.0",
 				"create-hash": "^1.2.0",
 				"create-hmac": "^1.1.7",
-				"elliptic": "^6.5.4",
+				"elliptic": "^6.5.7",
 				"inherits": "^2.0.4",
 				"parse-asn1": "^5.1.6",
 				"readable-stream": "^3.6.2",
@@ -7141,7 +7141,7 @@
 			"integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
 			"dependencies": {
 				"bn.js": "^4.1.0",
-				"elliptic": "^6.5.3"
+				"elliptic": "^6.5.7"
 			}
 		},
 		"node_modules/create-ecdh/node_modules/bn.js": {
@@ -7808,8 +7808,8 @@
 			"integrity": "sha512-9ItEpeu15hW5m8jKdriL+BQrgwDTXEL9pn4SkillWFu73ZNNNQ2BKKLS+ZHv2vC9UkNhosAeyfxOf/5OSeTCPA=="
 		},
 		"node_modules/elliptic": {
-			"version": "6.5.4",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+			"version": "6.5.7",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
 			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
 			"dependencies": {
 				"bn.js": "^4.11.9",
@@ -24890,7 +24890,7 @@
 				"browserify-rsa": "^4.1.0",
 				"create-hash": "^1.2.0",
 				"create-hmac": "^1.1.7",
-				"elliptic": "^6.5.4",
+				"elliptic": "^6.5.7",
 				"inherits": "^2.0.4",
 				"parse-asn1": "^5.1.6",
 				"readable-stream": "^3.6.2",
@@ -25463,7 +25463,7 @@
 			"integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
 			"requires": {
 				"bn.js": "^4.1.0",
-				"elliptic": "^6.5.3"
+				"elliptic": "^6.5.7"
 			},
 			"dependencies": {
 				"bn.js": {
@@ -25994,8 +25994,8 @@
 			"integrity": "sha512-9ItEpeu15hW5m8jKdriL+BQrgwDTXEL9pn4SkillWFu73ZNNNQ2BKKLS+ZHv2vC9UkNhosAeyfxOf/5OSeTCPA=="
 		},
 		"elliptic": {
-			"version": "6.5.4",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+			"version": "6.5.7",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
 			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
 			"requires": {
 				"bn.js": "^4.11.9",

--- a/packages/athena/package-lock.json
+++ b/packages/athena/package-lock.json
@@ -1689,9 +1689,9 @@
 			"dev": true
 		},
 		"node_modules/elliptic": {
-			"version": "6.5.4",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+			"version": "6.5.7",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+			"integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
 			"dependencies": {
 				"bn.js": "^4.11.9",
 				"brorand": "^1.1.0",
@@ -6720,9 +6720,9 @@
 			"dev": true
 		},
 		"elliptic": {
-			"version": "6.5.4",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-			"integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+			"version": "6.5.7",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+			"integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
 			"requires": {
 				"bn.js": "^4.11.9",
 				"brorand": "^1.1.0",

--- a/packages/athena/package-lock.json
+++ b/packages/athena/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"async": "3.2.*",
-				"axios": "^1.6.2",
+				"axios": "^1.7.4",
 				"bn.js": "4.11.*",
 				"body-parser": "^1.18.3",
 				"chokidar": "3.0.*",
@@ -980,11 +980,11 @@
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"node_modules/axios": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-			"integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+			"integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
 			"dependencies": {
-				"follow-redirects": "^1.15.0",
+				"follow-redirects": "^1.15.6",
 				"form-data": "^4.0.0",
 				"proxy-from-env": "^1.1.0"
 			}
@@ -6170,11 +6170,11 @@
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"axios": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-			"integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+			"integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
 			"requires": {
-				"follow-redirects": "^1.15.0",
+				"follow-redirects": "^1.15.6",
 				"form-data": "^4.0.0",
 				"proxy-from-env": "^1.1.0"
 			},

--- a/packages/athena/package.json
+++ b/packages/athena/package.json
@@ -28,7 +28,7 @@
 	},
 	"dependencies": {
 		"async": "3.2.*",
-		"axios": "^1.6.2",
+		"axios": "^1.7.4",
 		"bn.js": "4.11.*",
 		"body-parser": "^1.18.3",
 		"chokidar": "3.0.*",

--- a/packages/athena/package.json
+++ b/packages/athena/package.json
@@ -34,7 +34,7 @@
 		"chokidar": "3.0.*",
 		"compression": "1.7.*",
 		"cors": "2.8.*",
-		"elliptic": "^6.5.4",
+		"elliptic": "6.5.7",
 		"express": "^4.19.2",
 		"express-rate-limit": "3.4.*",
 		"express-session": "1.15.*",

--- a/packages/fabric-deployer/go.mod
+++ b/packages/fabric-deployer/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/docker/docker v25.0.5+incompatible // indirect
+	github.com/docker/docker v26.1.5+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/emicklei/go-restful v2.16.0+incompatible // indirect
@@ -39,6 +39,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
+	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/packages/fabric-deployer/go.sum
+++ b/packages/fabric-deployer/go.sum
@@ -52,8 +52,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/docker/docker v25.0.5+incompatible h1:UmQydMduGkrD5nQde1mecF/YnSbTOaPeFIeP5C4W+DE=
-github.com/docker/docker v25.0.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v26.1.5+incompatible h1:NEAxTwEjxV6VbBMBoGG3zPqbiJosIApZjxlbrG9q3/g=
+github.com/docker/docker v26.1.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
@@ -179,6 +179,8 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
+github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
#### Type of change
security fix / library update

#### Description
fix for CVE-2024-41110 - dockerR updated to v26.1.5
