### PR TITLE
Update auth header token for CA

### DIFF
--- a/packages/athena/libs/ca_lib.js
+++ b/packages/athena/libs/ca_lib.js
@@ -88,14 +88,17 @@ module.exports = (logger, ev, t) => {
 		const err = {};
 		err.statusCode = 500;
 
+		const path = fabricCAClient.baseAPI + 'identities' + '?ca=' + fabricCAClient.ca_name;
+		const method = 'GET';
+
 		// get the auth token
-		const auth_token = t.fabric_utils.generateAuthToken(null);
+		const auth_token = t.fabric_utils.generateAuthToken(null, path, method);
 
 		// build the request object to get all identities
 		const options = {
 			baseUrl: fabricCAClient.protocol + '//' + fabricCAClient.hostname + ':' + fabricCAClient.port,
-			url: fabricCAClient.baseAPI + 'identities' + '?ca=' + fabricCAClient.ca_name,
-			method: 'GET',
+			url: path,
+			method: method,
 			headers: {
 				Authorization: auth_token
 			},
@@ -151,15 +154,18 @@ module.exports = (logger, ev, t) => {
 		const err = {};
 		err.statusCode = 500;
 
+		const path = fabricCAClient.baseAPI + 'identities';
+		const method = 'POST';
+
 		// get the auth token
-		const auth_token = t.fabric_utils.generateAuthToken(newIdentity);
+		const auth_token = t.fabric_utils.generateAuthToken(newIdentity, path, method);
 
 		// build the request object to get all identities
 		const options = {
 			baseUrl: fabricCAClient.protocol + '//' + fabricCAClient.hostname + ':' + fabricCAClient.port,
-			url: fabricCAClient.baseAPI + 'identities',
+			url: path,
 			body: JSON.stringify(newIdentity),
-			method: 'POST',
+			method: method,
 			headers: {
 				Authorization: auth_token
 			},
@@ -223,14 +229,17 @@ module.exports = (logger, ev, t) => {
 		const err = {};
 		err.statusCode = 500;
 
+		const path = fabricCAClient.baseAPI + 'affiliations' + '?ca=' + fabricCAClient.ca_name;
+		const method = 'GET';
+
 		// get the auth token
-		const auth_token = t.fabric_utils.generateAuthToken(null);
+		const auth_token = t.fabric_utils.generateAuthToken(null, path, method);
 
 		// build the request object to get all identities
 		const options = {
 			baseUrl: fabricCAClient.protocol + '//' + fabricCAClient.hostname + ':' + fabricCAClient.port,
-			url: fabricCAClient.baseAPI + 'affiliations' + '?ca=' + fabricCAClient.ca_name,
-			method: 'GET',
+			url: path,
+			method: method,
 			headers: {
 				Authorization: auth_token
 			},
@@ -303,15 +312,18 @@ module.exports = (logger, ev, t) => {
 				certificate_request: t.key_lib.generateCSR('CN=' + fabricCAClient.enrollmentID, pair.prvKeyObj)
 			};
 
+			const path = fabricCAClient.baseAPI + 'reenroll';
+			const method = 'POST';
+
 			// get the auth token (csr)
-			const auth_token = t.fabric_utils.generateAuthToken(reenrollCSR, t.signingIdentity);
+			const auth_token = t.fabric_utils.generateAuthToken(reenrollCSR, path, method);
 
 			// build the request re-enroll the user
 			const options = {
 				baseUrl: fabricCAClient.protocol + '//' + fabricCAClient.hostname + ':' + fabricCAClient.port,
-				url: fabricCAClient.baseAPI + 'reenroll',
+				url: path,
 				body: JSON.stringify(reenrollCSR),
-				method: 'POST',
+				method: method,
 				headers: {
 					Authorization: auth_token
 				},
@@ -377,14 +389,17 @@ module.exports = (logger, ev, t) => {
 		const err = {};
 		err.statusCode = 500;
 
+		const path = fabricCAClient.baseAPI + 'identities/' + enroll_id_to_delete;
+		const method = 'DELETE';
+
 		// get the auth token
-		const auth_token = t.fabric_utils.generateAuthToken(null);
+		const auth_token = t.fabric_utils.generateAuthToken(null, path, method);
 
 		// build the request object to get all identities
 		const options = {
 			baseUrl: fabricCAClient.protocol + '//' + fabricCAClient.hostname + ':' + fabricCAClient.port,
-			url: fabricCAClient.baseAPI + 'identities/' + enroll_id_to_delete,
-			method: 'DELETE',
+			url: path,
+			method: method,
 			headers: {
 				Authorization: auth_token
 			},


### PR DESCRIPTION
When interacting with Fabric CA REST services,
utilize the updated auth header token format
that includes the URL path and method.

The old format has been deprecated for a long time (since Fabric CA v1.4.0) since the new format is more secure. New versions of Fabric CA (v1.5.14 and later) will not support the old format by default (although they can still support the old format by setting `FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3=true`).

For reference see similar change in legacy Node SDK that never got propagated to the console Fabric CA client:
https://github.com/hyperledger/fabric-sdk-node/commit/602f557cc9fa07d444bb707aeef4eb3b94757779

And the original change in Fabric CA that is driving this change:
https://github.com/hyperledger/fabric-ca/commit/99517e9d983750e7e8c9a8db9eeda7008e37d7ff

Note that the new format became effective in Fabric CA v1.4.0 (2019), therefore console will require Fabric CA v1.4.0 or later, which should not be a problem at this stage.