### PR TITLE
Update auth header token for CA (stitch)

### DIFF
--- a/packages/stitch/src/libs/crypto_misc.ts
+++ b/packages/stitch/src/libs/crypto_misc.ts
@@ -458,7 +458,7 @@ function fmtKey(key: object | string, type: string) {
 //------------------------------------------------------------------
 // Generate authorization token required for accessing fabric-ca APIs
 //------------------------------------------------------------------
-function generateCaAuthToken(opts: { client_prv_key_b64pem: string, client_cert_b64pem: string, body_obj: any }, cb: Function) {
+function generateCaAuthToken(opts: { client_prv_key_b64pem: string, client_cert_b64pem: string, body_obj: any, path: string, method: string }, cb: Function) {
 	let prvKeyPem = decode_b64_pem(opts.client_prv_key_b64pem);
 	let client_cert_b64pem = btoa(decode_b64_pem(opts.client_cert_b64pem));	// decode and encode to catch non encoded certs
 	let payload = null;
@@ -468,6 +468,11 @@ function generateCaAuthToken(opts: { client_prv_key_b64pem: string, client_cert_
 		payload = reqBodyB64 + '.' + client_cert_b64pem;
 	} else {
 		payload = '.' + client_cert_b64pem;
+	}
+
+	if (opts.path && opts.method) {
+		const s = btoa(opts.path);
+		payload = opts.method + '.' + s + '.' + payload;
 	}
 
 	scSign({ prvKeyPEM: prvKeyPem, b_msg: utf8StrToUint8Array(payload) }, (_: any, b_signature: any) => {	// subtle crypto method does not need the has function


### PR DESCRIPTION
When interacting with Fabric CA REST services,
utilize the updated auth header token format
that includes the URL path and method.

The old format has been deprecated for a long time (since Fabric CA v1.4.0) since the new format is more secure.
New versions of Fabric CA (v1.5.14 and later) will not support the old format by default
(although they can still support the old format by setting FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3=true).

For reference see similar change in legacy Node SDK that never got propagated to the console Fabric CA client:
https://github.com/hyperledger/fabric-sdk-node/commit/602f557cc9fa07d444bb707aeef4eb3b94757779

And the original change in Fabric CA that is driving this change:
https://github.com/hyperledger/fabric-ca/commit/99517e9d983750e7e8c9a8db9eeda7008e37d7ff

Note that the new format became effective in Fabric CA v1.4.0 (2019), therefore console will require Fabric CA v1.4.0 or later, which should not be a problem at this stage.