### PR TITLE
Support newer versions of docker compose plugin

### DIFF
--- a/scripts/setupConsole.sh
+++ b/scripts/setupConsole.sh
@@ -3,13 +3,13 @@
 SRC_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" # Where the script lives
 
 function networkUp() {
-	docker-compose -f ${SRC_DIR}/../docker/docker-compose-console.yaml up -d
-	docker-compose -f ${SRC_DIR}/../docker/docker-compose-grpc-web.yaml up -d
+	docker compose -f ${SRC_DIR}/../docker/docker-compose-console.yaml up -d
+	docker compose -f ${SRC_DIR}/../docker/docker-compose-grpc-web.yaml up -d
 }
 
 function networkDown() {
-	docker-compose -f ${SRC_DIR}/../docker/docker-compose-console.yaml down
-	docker-compose -f ${SRC_DIR}/../docker/docker-compose-grpc-web.yaml down
+	docker compose -f ${SRC_DIR}/../docker/docker-compose-console.yaml down
+	docker compose -f ${SRC_DIR}/../docker/docker-compose-grpc-web.yaml down
 }
 
 function printHelp() {


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description
It looks like the old docker-compose syntax is no longer supported. On a fresh install of docker and the docker compose plugin, this error will occur https://github.com/hyperledger-labs/fabric-operations-console/issues/847. This PR updates to the updated syntax of `docker compose` and resolves this error.
