### PR TITLE
Nominate Thomas Leung as Maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,23 @@
+# Maintainers
+
+**Active maintainers**
+
+| Name                 | GitHub                                     | email                             |
+| -------------------- | ------------------------------------------ | --------------------------------- |
+| Dave Enyeart         | [denyeart][denyeart]                       | <enyeart@us.ibm.com>              |
+| David Huffman        | [dshuffma-ibm][dshuffma-ibm]               | <dshuffma@us.ibm.com>             |
+| Ketul Shah           | [ketulsha][ketulsha]                       | <shah.ketul@ibm.com>              |
+| Muthu Sundaravadivel | [MuthuSundaravadivel][MuthuSundaravadivel] | <muthu.sundaravadivel@in.ibm.com> |
+| Shoaeb Jindani       | [shoaebjindani][shoaebjindani]             | <jindani.shoaeb@ibm.com>          |
+| Thomas Leung         | [Thomas-Leung][Thomas-Leung]               | <thomas.leung@ibm.com>            |
+
+
+
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+
+[denyeart]: https://github.com/denyeart
+[dshuffma-ibm]: https://github.com/dshuffma-ibm
+[ketulsha]: https://github.com/ketulsha
+[MuthuSundaravadivel]: https://github.com/MuthuSundaravadivel
+[shoaebjindani]: https://github.com/shoaebjindani
+[Thomas-Leung]: https://github.com/Thomas-Leung


### PR DESCRIPTION
This repository did not previously have a MAINTAINERS.md file.
Therefore this commit adds the MAINTAINERS.md file and adds Thomas.

