### PR TITLE
Fix Typos in Comment

### DIFF
--- a/packages/stitch/src/protoc/input/v1.4/peer/proposal_response.proto
+++ b/packages/stitch/src/protoc/input/v1.4/peer/proposal_response.proto
@@ -75,7 +75,7 @@ message Response {
 message ProposalResponsePayload {
 
 	// Hash of the proposal that triggered this response. The hash is used to
-	// link a response with its proposal, both for bookeeping purposes on an
+	// link a response with its proposal, both for bookkeeping purposes on an
 	// asynchronous system and for security reasons (accountability,
 	// non-repudiation). The hash usually covers the entire Proposal message
 	// (byte-by-byte). However this implies that the hash can only be verified

--- a/packages/stitch/src/protoc/input/v1.4/peer/resources.proto
+++ b/packages/stitch/src/protoc/input/v1.4/peer/resources.proto
@@ -24,14 +24,14 @@ message ChaincodeIdentifier {
 // ChaincodeValidation instructs the peer how transactions for this chaincode should be
 // validated.  The only validation mechanism which ships with fabric today is the standard
 // 'vscc' validation mechanism.  This built in validation method utilizes an endorsement policy
-// which checks that a sufficient number of signatures have been included.  The 'arguement'
+// which checks that a sufficient number of signatures have been included.  The 'argument'
 // field encodes any parameters required by the validation implementation.
 message ChaincodeValidation {
     string name = 1;    // Specifies which code to run to validate transactions, defaults to 'vscc'
     bytes argument = 2; // When 'vscc' a marshaled VSCCArgs
 }
 
-// VSCCArgs is passed (marshaled) as a parameter to the VSCC imlementation via the
+// VSCCArgs is passed (marshaled) as a parameter to the VSCC implementation via the
 // argument field of the ChaincodeValidation message.
 message VSCCArgs {
     string endorsement_policy_ref = 1;  // A named reference to an endorsement policy,

--- a/packages/stitch/src/protoc/input/v1.4/peer/signed_cc_dep_spec.proto
+++ b/packages/stitch/src/protoc/input/v1.4/peer/signed_cc_dep_spec.proto
@@ -31,7 +31,7 @@ message SignedChaincodeDeploymentSpec {
 	// This is the instantiation policy which is identical in structure
 	// to endorsement policy.  This policy is checked by the VSCC at commit
 	// time on the instantiation (all peers will get the same policy as it
-	// will be part of the LSCC instantation record and will be part of the
+	// will be part of the LSCC instantiation record and will be part of the
 	// hash as well)
 	bytes instantiation_policy = 2;
 
@@ -39,4 +39,3 @@ message SignedChaincodeDeploymentSpec {
 	// chaincode_deployment_spec and Endorsement.endorser.
 	repeated Endorsement owner_endorsements = 3;
 }
-


### PR DESCRIPTION
#### Type of change
- Documentation update

#### Description
Corrected misspellings:
- `bookeeping` → `bookkeeping`
- `arguement` → `argument`
- `instantation` → `instantiation`
- `imlementation` → `implementation`

