### PR TITLE
CVE-2026-42033 | updated axios package

### DIFF
--- a/packages/athena/.nsprc
+++ b/packages/athena/.nsprc
@@ -3,5 +3,10 @@
 		"active": true,
 		"notes": "No fix is available yet. Skipping to allow the pipeline to proceed.",
 		"expiry": 1803859200000
+	},
+	"1116970": {
+		"active": true,
+		"notes": "uuid contains breaking change. Skipping for now to allow pipeline to proceed.",
+		"expiry": 1803859200000
 	}
 }

--- a/packages/athena/package-lock.json
+++ b/packages/athena/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"async": "^3.2.5",
-				"axios": "^1.15.0",
+				"axios": "^1.15.2",
 				"bn.js": "^5.2.3",
 				"body-parser": "^1.18.3",
 				"chokidar": "3.0.*",
@@ -1189,9 +1189,9 @@
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"node_modules/axios": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-			"integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+			"version": "1.15.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+			"integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
 			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.15.11",
@@ -5602,10 +5602,11 @@
 			}
 		},
 		"node_modules/uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+			"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+			"license": "MIT",
 			"bin": {
 				"uuid": "bin/uuid"
 			}
@@ -6758,9 +6759,9 @@
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"axios": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-			"integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+			"version": "1.15.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+			"integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
 			"requires": {
 				"follow-redirects": "^1.15.11",
 				"form-data": "^4.0.4",
@@ -9948,9 +9949,9 @@
 			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
 		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+			"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
 		},
 		"vary": {
 			"version": "1.1.2",

--- a/packages/athena/package.json
+++ b/packages/athena/package.json
@@ -28,7 +28,7 @@
 	},
 	"dependencies": {
 		"async": "^3.2.5",
-		"axios": "^1.15.0",
+		"axios": "^1.15.2",
 		"bn.js": "^5.2.3",
 		"body-parser": "^1.18.3",
 		"chokidar": "3.0.*",


### PR DESCRIPTION
CVE-2026-42033 | updated axios package
Skipping uuid package as it requires breaking changes