### PR TITLE
chore: upgrade uuid from 3.x to 11.1.1

### DIFF
--- a/packages/apollo/package-lock.json
+++ b/packages/apollo/package-lock.json
@@ -51,7 +51,7 @@
 				"redux-thunk": "^3.1.0",
 				"semver": "^7.5.2",
 				"tar-stream": "^3.1.7",
-				"uuid": "^3.4.0",
+				"uuid": "^11.1.1",
 				"validator": "^13.15.22"
 			},
 			"devDependencies": {
@@ -18356,6 +18356,17 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/request/node_modules/uuid": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"uuid": "bin/uuid"
+			}
+		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -20789,12 +20800,16 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"node_modules/uuid": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
 			"bin": {
-				"uuid": "bin/uuid"
+				"uuid": "dist/esm/bin/uuid"
 			}
 		},
 		"node_modules/v8-to-istanbul": {
@@ -34798,6 +34813,14 @@
 				"tough-cookie": "^4.1.3",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
+				}
 			}
 		},
 		"require-directory": {
@@ -36502,9 +36525,9 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"uuid": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
 		},
 		"v8-to-istanbul": {
 			"version": "8.1.1",

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -45,7 +45,7 @@
 		"redux-thunk": "^3.1.0",
 		"semver": "^7.5.2",
 		"tar-stream": "^3.1.7",
-		"uuid": "^3.4.0",
+		"uuid": "^11.1.1",
 		"validator": "^13.15.22"
 	},
 	"scripts": {

--- a/packages/apollo/src/rest/SignatureRestApi.js
+++ b/packages/apollo/src/rest/SignatureRestApi.js
@@ -23,7 +23,7 @@ import IdentityApi from './IdentityApi';
 import { RestApi } from './RestApi';
 import StitchApi from './StitchApi';
 
-const uuidv4 = require('uuid/v4');
+const { v4: uuidv4 } = require('uuid');
 const Log = new Logger('SignatureRequestApi');
 
 class SignatureRestApi {

--- a/packages/athena/app.js
+++ b/packages/athena/app.js
@@ -23,7 +23,7 @@ const tools = {										// stateless util libs should go here, ~8% faster start
 	path: require('path'),
 	async: require('async'),
 	crypto: require('crypto'),
-	uuidv4: require('uuid/v4'),
+	uuidv4: require('uuid').v4,
 	yaml: require('js-yaml'),
 	os: require('os'),
 	NodeCache: require('node-cache'),

--- a/packages/athena/package-lock.json
+++ b/packages/athena/package-lock.json
@@ -31,7 +31,7 @@
 				"passport-oauth": "1.0.*",
 				"protobufjs": "^7.5.5",
 				"selfsigned": "^4.0.0",
-				"uuid": "3.3.*",
+				"uuid": "^11.1.1",
 				"winston": "2.4.*",
 				"ws": "7.5.*",
 				"zlib": "^1.0.5"
@@ -82,6 +82,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.0.tgz",
 			"integrity": "sha512-8YqpRig5NmIHlMLw09zMlPTvUVMILjqCOtVgu+TVNWEBvy9b5I3RRyhqnrV4hjgEK7n8P9OqvkWJAFmEL6Wwfw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.12.13",
 				"@babel/generator": "^7.14.0",
@@ -1034,6 +1035,7 @@
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2054,6 +2056,7 @@
 			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
@@ -5601,13 +5604,16 @@
 			}
 		},
 		"node_modules/uuid": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-			"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
-			"deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
 			"license": "MIT",
 			"bin": {
-				"uuid": "bin/uuid"
+				"uuid": "dist/esm/bin/uuid"
 			}
 		},
 		"node_modules/vary": {
@@ -5914,6 +5920,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.0.tgz",
 			"integrity": "sha512-8YqpRig5NmIHlMLw09zMlPTvUVMILjqCOtVgu+TVNWEBvy9b5I3RRyhqnrV4hjgEK7n8P9OqvkWJAFmEL6Wwfw==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@babel/code-frame": "^7.12.13",
 				"@babel/generator": "^7.14.0",
@@ -6642,7 +6649,8 @@
 			"version": "8.16.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
@@ -7397,6 +7405,7 @@
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
 			"integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
@@ -9948,9 +9957,9 @@
 			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
 		},
 		"uuid": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-			"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
 		},
 		"vary": {
 			"version": "1.1.2",

--- a/packages/athena/package.json
+++ b/packages/athena/package.json
@@ -49,7 +49,7 @@
 		"passport-oauth": "1.0.*",
 		"protobufjs": "^7.5.5",
 		"selfsigned": "^4.0.0",
-		"uuid": "3.3.*",
+		"uuid": "^11.1.1",
 		"winston": "2.4.*",
 		"ws": "7.5.*",
 		"zlib": "^1.0.5"

--- a/packages/athena/test/axios.js
+++ b/packages/athena/test/axios.js
@@ -23,7 +23,7 @@ const tools = {										// stateless util libs should go here, ~8% faster start
 	path: require('path'),
 	async: require('async'),
 	crypto: require('crypto'),
-	uuidv4: require('uuid/v4'),
+	uuidv4: require('uuid').v4,
 	yaml: require('js-yaml'),
 	os: require('os'),
 	NodeCache: require('node-cache'),

--- a/packages/athena/test/test-suites/common-test-framework.js
+++ b/packages/athena/test/test-suites/common-test-framework.js
@@ -23,7 +23,7 @@ const tools = {										// stateless util libs should go here, ~8% faster start
 	path: require('path'),
 	async: require('async'),
 	crypto: require('crypto'),
-	uuidv4: require('uuid/v4'),
+	uuidv4: require('uuid').v4,
 	yaml: require('js-yaml'),
 	js_rsa: require('jsrsasign'),
 	passport: require('passport'),


### PR DESCRIPTION
- Updated uuid in packages/apollo from 3.4.0 to 11.1.1
- Updated uuid in packages/athena from 3.3.* to 11.1.1
- Updated uuid imports to use new v11 API syntax
